### PR TITLE
Collision Response in State Estimator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "2025.2.1"
     id "com.peterabeles.gversion" version "1.10"
     id "io.freefair.lombok" version "8.4"
+    id 'checkstyle'
 }
 
 java {
@@ -146,4 +147,8 @@ gversion {
     dateFormat   = "yyyy-MM-dd HH:mm:ss z"
     timeZone     = "America/New_York"
     indent       = "  "
+}
+
+checkstyle {
+    configFile file("checks.xml")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "2025.2.1"
     id "com.peterabeles.gversion" version "1.10"
     id "io.freefair.lombok" version "8.4"
-    id 'checkstyle'
 }
 
 java {
@@ -147,8 +146,4 @@ gversion {
     dateFormat   = "yyyy-MM-dd HH:mm:ss z"
     timeZone     = "America/New_York"
     indent       = "  "
-}
-
-checkstyle {
-    configFile file("checks.xml")
 }

--- a/checks.xml
+++ b/checks.xml
@@ -318,9 +318,9 @@
       <property name="forbiddenSummaryFragments"
                value="^@return the *|^This method returns |^A [{]@code [_a-zA-Z0-9]+[}]( is a )"/>
     </module> -->
-    <module name="JavadocParagraph">
+    <!-- <module name="JavadocParagraph">
       <property name="allowNewlineParagraph" value="true" />
-    </module>
+    </module> -->
     <module name="JavadocStyle">
       <property name="checkFirstSentence" value="false" />
     </module>

--- a/checks.xml
+++ b/checks.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC
-          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
@@ -16,257 +14,259 @@
     Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
  -->
 
-<module name = "Checker">
-  <property name="charset" value="UTF-8"/>
+<module name="Checker">
+  <property name="charset" value="UTF-8" />
 
-  <property name="severity" value="warning"/>
+  <property name="severity" value="warning" />
 
-  <property name="fileExtensions" value="java, properties, xml"/>
+  <property name="fileExtensions" value="java, properties, xml" />
   <!-- Excludes all 'module-info.java' files              -->
   <!-- See https://checkstyle.org/config_filefilters.html -->
   <module name="BeforeExecutionExclusionFileFilter">
-    <property name="fileNamePattern" value="module\-info\.java$"/>
+    <property name="fileNamePattern" value="BuildConstants.java$" />
   </module>
   <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
   <module name="SuppressionFilter">
     <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
-           default="checkstyle-suppressions.xml" />
-    <property name="optional" value="true"/>
+      default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true" />
   </module>
 
   <!-- Checks for whitespace                               -->
   <!-- See http://checkstyle.org/config_whitespace.html -->
   <module name="FileTabCharacter">
-    <property name="eachLine" value="true"/>
+    <property name="eachLine" value="true" />
   </module>
 
   <module name="LineLength">
-    <property name="fileExtensions" value="java"/>
-    <property name="max" value="100"/>
+    <property name="fileExtensions" value="java" />
+    <property name="max" value="100" />
     <!-- <property name="severity" value="ignore"/> -->
-    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
   </module>
 
   <module name="TreeWalker">
-    <module name="OuterTypeFilename"/>
+    <module name="OuterTypeFilename" />
     <module name="IllegalTokenText">
-      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL" />
       <property name="format"
-               value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+        value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)" />
       <property name="message"
-               value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        value="Consider using special escape sequence instead of octal value or Unicode escaped value." />
     </module>
     <module name="AvoidEscapedUnicodeCharacters">
-      <property name="allowEscapesForControlCharacters" value="true"/>
-      <property name="allowByTailComment" value="true"/>
-      <property name="allowNonPrintableEscapes" value="true"/>
+      <property name="allowEscapesForControlCharacters" value="true" />
+      <property name="allowByTailComment" value="true" />
+      <property name="allowNonPrintableEscapes" value="true" />
     </module>
-    <module name="AvoidStarImport"/>
-    <module name="OneTopLevelClass"/>
+    <module name="AvoidStarImport" />
+    <module name="OneTopLevelClass" />
     <module name="NoLineWrap">
-      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT" />
     </module>
     <module name="EmptyBlock">
-      <property name="option" value="TEXT"/>
+      <property name="option" value="TEXT" />
       <property name="tokens"
-               value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH" />
     </module>
     <module name="NeedBraces">
       <property name="tokens"
-               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+        value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE" />
     </module>
     <module name="LeftCurly">
       <property name="tokens"
-               value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+        value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
                     INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
                     LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
-                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF" />
     </module>
     <module name="RightCurly">
-      <property name="id" value="RightCurlySame"/>
+      <property name="id" value="RightCurlySame" />
       <property name="tokens"
-               value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
-                    LITERAL_DO"/>
+        value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO" />
     </module>
     <module name="RightCurly">
-      <property name="id" value="RightCurlyAlone"/>
-      <property name="option" value="alone"/>
+      <property name="id" value="RightCurlyAlone" />
+      <property name="option" value="alone" />
       <property name="tokens"
-               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+        value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF"/>
+                    COMPACT_CTOR_DEF" />
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
-      <property name="id" value="RightCurlyAlone"/>
-      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
-                                     or preceding-sibling::*[last()][self::LCURLY]]"/>
+      <property name="id" value="RightCurlyAlone" />
+      <property name="query"
+        value="//RCURLY[parent::SLIST[count(./*)=1]
+                                     or preceding-sibling::*[last()][self::LCURLY]]" />
     </module>
     <module name="WhitespaceAfter">
       <property name="tokens"
-               value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
-                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE"/>
+        value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE" />
     </module>
     <module name="WhitespaceAround">
-      <property name="allowEmptyConstructors" value="true"/>
-      <property name="allowEmptyLambdas" value="true"/>
-      <property name="allowEmptyMethods" value="true"/>
-      <property name="allowEmptyTypes" value="true"/>
-      <property name="allowEmptyLoops" value="true"/>
-      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="allowEmptyConstructors" value="true" />
+      <property name="allowEmptyLambdas" value="true" />
+      <property name="allowEmptyMethods" value="true" />
+      <property name="allowEmptyTypes" value="true" />
+      <property name="allowEmptyLoops" value="true" />
+      <property name="ignoreEnhancedForColon" value="false" />
       <property name="tokens"
-               value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+        value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
                     BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
                     LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
                     LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
                     LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
                     NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
-                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND" />
       <message key="ws.notFollowed"
-              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+        value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)" />
       <message key="ws.notPreceded"
-              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        value="WhitespaceAround: ''{0}'' is not preceded with whitespace." />
     </module>
-    <module name="OneStatementPerLine"/>
-    <module name="MultipleVariableDeclarations"/>
-    <module name="ArrayTypeStyle"/>
-    <module name="MissingSwitchDefault"/>
-    <module name="FallThrough"/>
-    <module name="UpperEll"/>
-    <module name="ModifierOrder"/>
+    <module name="OneStatementPerLine" />
+    <module name="MultipleVariableDeclarations" />
+    <module name="ArrayTypeStyle" />
+    <module name="MissingSwitchDefault" />
+    <module name="FallThrough" />
+    <module name="UpperEll" />
+    <module name="ModifierOrder" />
     <module name="EmptyLineSeparator">
       <property name="tokens"
-               value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+        value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
                     STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF"/>
-      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+                    COMPACT_CTOR_DEF" />
+      <property name="allowNoEmptyLineBetweenFields" value="true" />
     </module>
     <module name="SeparatorWrap">
-      <property name="id" value="SeparatorWrapDot"/>
-      <property name="tokens" value="DOT"/>
-      <property name="option" value="nl"/>
+      <property name="id" value="SeparatorWrapDot" />
+      <property name="tokens" value="DOT" />
+      <property name="option" value="nl" />
     </module>
     <module name="SeparatorWrap">
-      <property name="id" value="SeparatorWrapComma"/>
-      <property name="tokens" value="COMMA"/>
-      <property name="option" value="EOL"/>
+      <property name="id" value="SeparatorWrapComma" />
+      <property name="tokens" value="COMMA" />
+      <property name="option" value="EOL" />
     </module>
     <module name="SeparatorWrap">
       <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
-      <property name="id" value="SeparatorWrapEllipsis"/>
-      <property name="tokens" value="ELLIPSIS"/>
-      <property name="option" value="EOL"/>
+      <property name="id" value="SeparatorWrapEllipsis" />
+      <property name="tokens" value="ELLIPSIS" />
+      <property name="option" value="EOL" />
     </module>
     <module name="SeparatorWrap">
       <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
-      <property name="id" value="SeparatorWrapArrayDeclarator"/>
-      <property name="tokens" value="ARRAY_DECLARATOR"/>
-      <property name="option" value="EOL"/>
+      <property name="id" value="SeparatorWrapArrayDeclarator" />
+      <property name="tokens" value="ARRAY_DECLARATOR" />
+      <property name="option" value="EOL" />
     </module>
     <module name="SeparatorWrap">
-      <property name="id" value="SeparatorWrapMethodRef"/>
-      <property name="tokens" value="METHOD_REF"/>
-      <property name="option" value="nl"/>
+      <property name="id" value="SeparatorWrapMethodRef" />
+      <property name="tokens" value="METHOD_REF" />
+      <property name="option" value="nl" />
     </module>
     <module name="PackageName">
-      <property name="format" value="^[_a-z]+(\.[_a-z][_a-z0-9]*)*$"/>
+      <property name="format" value="^[_a-z]+(\.[_a-z][_a-z0-9]*)*$" />
       <message key="name.invalidPattern"
-             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        value="Package name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="TypeName">
-      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
-                    ANNOTATION_DEF, RECORD_DEF"/>
-      <property name="format" value="^[A-Z][_a-zA-Z0-9]*$"/>
+      <property name="tokens"
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF" />
+      <property name="format" value="^[A-Z][_a-zA-Z0-9]*$" />
       <message key="name.invalidPattern"
-             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        value="Type name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="MemberName">
-      <property name="format" value="^[_a-z][_a-zA-Z0-9]*$"/>
+      <property name="format" value="^[_a-z][_a-zA-Z0-9]*$" />
       <message key="name.invalidPattern"
-             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        value="Member name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="ParameterName">
-      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$" />
       <message key="name.invalidPattern"
-             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        value="Parameter name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="LambdaParameterName">
-      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$" />
       <message key="name.invalidPattern"
-             value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+        value="Lambda parameter name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="CatchParameterName">
-      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$" />
       <message key="name.invalidPattern"
-             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        value="Catch parameter name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="LocalVariableName">
-      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$" />
       <message key="name.invalidPattern"
-             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        value="Local variable name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="PatternVariableName">
-      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$" />
       <message key="name.invalidPattern"
-             value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+        value="Pattern variable name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="ClassTypeParameterName">
-      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][_a-zA-Z0-9]*[T]$)"/>
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][_a-zA-Z0-9]*[T]$)" />
       <message key="name.invalidPattern"
-             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        value="Class type name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="RecordComponentName">
-      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[_a-z]([_a-zA-Z0-9]*)?$" />
       <message key="name.invalidPattern"
-               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+        value="Record component name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="RecordTypeParameterName">
-      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][_a-zA-Z0-9]*[T]$)"/>
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][_a-zA-Z0-9]*[T]$)" />
       <message key="name.invalidPattern"
-               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+        value="Record type name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="MethodTypeParameterName">
-      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][_a-zA-Z0-9]*[T]$)"/>
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][_a-zA-Z0-9]*[T]$)" />
       <message key="name.invalidPattern"
-             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        value="Method type name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="InterfaceTypeParameterName">
-      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][_a-zA-Z0-9]*[T]$)"/>
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][_a-zA-Z0-9]*[T]$)" />
       <message key="name.invalidPattern"
-             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        value="Interface type name ''{0}'' must match pattern ''{1}''." />
     </module>
-    <module name="NoFinalizer"/>
+    <module name="NoFinalizer" />
     <module name="GenericWhitespace">
       <message key="ws.followed"
-             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+        value="GenericWhitespace ''{0}'' is followed by whitespace." />
       <message key="ws.preceded"
-             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+        value="GenericWhitespace ''{0}'' is preceded with whitespace." />
       <message key="ws.illegalFollow"
-             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+        value="GenericWhitespace ''{0}'' should followed by whitespace." />
       <message key="ws.notPreceded"
-             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        value="GenericWhitespace ''{0}'' is not preceded with whitespace." />
     </module>
     <module name="Indentation">
-      <property name="basicOffset" value="4"/>
-      <property name="braceAdjustment" value="0"/>
-      <property name="caseIndent" value="4"/>
-      <property name="throwsIndent" value="4"/>
-      <property name="lineWrappingIndentation" value="4"/>
-      <property name="arrayInitIndent" value="4"/>
+      <property name="basicOffset" value="4" />
+      <property name="braceAdjustment" value="0" />
+      <property name="caseIndent" value="4" />
+      <property name="throwsIndent" value="4" />
+      <property name="lineWrappingIndentation" value="4" />
+      <property name="arrayInitIndent" value="4" />
     </module>
     <module name="AbbreviationAsWordInName">
-      <property name="ignoreFinal" value="false"/>
-      <property name="allowedAbbreviationLength" value="200"/>
+      <property name="ignoreFinal" value="false" />
+      <property name="allowedAbbreviationLength" value="200" />
       <property name="tokens"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
-                    RECORD_COMPONENT_DEF"/>
+                    RECORD_COMPONENT_DEF" />
     </module>
-    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
-    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="NoWhitespaceBeforeCaseDefaultColon" />
+    <module name="OverloadMethodsDeclarationOrder" />
     <module name="VariableDeclarationUsageDistance">
-      <property name="severity" value="ignore"/>
+      <property name="severity" value="ignore" />
     </module>
     <!-- <module name="CustomImportOrder">
       <property name="sortImportsInGroupAlphabetically" value="true"/>
@@ -276,98 +276,99 @@
     </module> -->
     <module name="MethodParamPad">
       <property name="tokens"
-               value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
-                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF"/>
+        value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF" />
     </module>
     <module name="NoWhitespaceBefore">
       <property name="tokens"
-               value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
-                    LABELED_STAT, METHOD_REF"/>
-      <property name="allowLineBreaks" value="true"/>
+        value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF" />
+      <property name="allowLineBreaks" value="true" />
     </module>
     <module name="ParenPad">
       <property name="tokens"
-               value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+        value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
                     EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
                     METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
-                    RECORD_DEF"/>
+                    RECORD_DEF" />
     </module>
     <module name="OperatorWrap">
-      <property name="option" value="NL"/>
+      <property name="option" value="NL" />
       <property name="tokens"
-               value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+        value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
                     LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
-                    TYPE_EXTENSION_AND "/>
+                    TYPE_EXTENSION_AND " />
     </module>
     <module name="AnnotationLocation">
-      <property name="id" value="AnnotationLocationMostCases"/>
+      <property name="id" value="AnnotationLocationMostCases" />
       <property name="tokens"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
-                      RECORD_DEF, COMPACT_CTOR_DEF"/>
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                      RECORD_DEF, COMPACT_CTOR_DEF" />
     </module>
     <module name="AnnotationLocation">
-      <property name="id" value="AnnotationLocationVariables"/>
-      <property name="tokens" value="VARIABLE_DEF"/>
-      <property name="allowSamelineMultipleAnnotations" value="true"/>
+      <property name="id" value="AnnotationLocationVariables" />
+      <property name="tokens" value="VARIABLE_DEF" />
+      <property name="allowSamelineMultipleAnnotations" value="true" />
     </module>
-    <module name="NonEmptyAtclauseDescription"/>
-    <module name="InvalidJavadocPosition"/>
-    <module name="JavadocTagContinuationIndentation"/>
+    <module name="NonEmptyAtclauseDescription" />
+    <module name="InvalidJavadocPosition" />
+    <module name="JavadocTagContinuationIndentation" />
     <!-- <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments"
                value="^@return the *|^This method returns |^A [{]@code [_a-zA-Z0-9]+[}]( is a )"/>
     </module> -->
     <module name="JavadocParagraph">
-      <property name="allowNewlineParagraph" value="false"/>
+      <property name="allowNewlineParagraph" value="true" />
     </module>
     <module name="JavadocStyle">
-      <property name="checkFirstSentence" value="false"/>
+      <property name="checkFirstSentence" value="false" />
     </module>
-    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup" />
     <module name="AtclauseOrder">
-      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated" />
       <property name="target"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF" />
     </module>
     <module name="JavadocMethod">
-      <property name="accessModifiers" value="public"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+      <property name="accessModifiers" value="public" />
+      <property name="allowMissingParamTags" value="true" />
+      <property name="allowMissingReturnTag" value="true" />
+      <property name="allowedAnnotations" value="Override, Test" />
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF" />
     </module>
     <module name="MissingJavadocMethod">
-      <property name="scope" value="public"/>
-      <property name="minLineCount" value="2"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
-                                   COMPACT_CTOR_DEF"/>
+      <property name="scope" value="public" />
+      <property name="minLineCount" value="2" />
+      <property name="allowedAnnotations" value="Override, Test" />
+      <property name="tokens"
+        value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF" />
     </module>
     <module name="MissingJavadocType">
-      <property name="scope" value="protected"/>
+      <property name="scope" value="protected" />
       <property name="tokens"
-                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
-                      RECORD_DEF, ANNOTATION_DEF"/>
-      <property name="excludeScope" value="nothing"/>
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF" />
+      <property name="excludeScope" value="nothing" />
     </module>
     <module name="MethodName">
-      <property name="format" value="^[_a-z][_a-zA-Z0-9_]*$"/>
+      <property name="format" value="^[_a-z][_a-zA-Z0-9_]*$" />
       <message key="name.invalidPattern"
-             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        value="Method name ''{0}'' must match pattern ''{1}''." />
     </module>
-    <module name="SingleLineJavadoc"/>
+    <module name="SingleLineJavadoc" />
     <module name="EmptyCatchBlock">
-      <property name="exceptionVariableName" value="expected"/>
+      <property name="exceptionVariableName" value="expected" />
     </module>
     <module name="CommentsIndentation">
-      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN" />
     </module>
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
-             default="checkstyle-xpath-suppressions.xml" />
-      <property name="optional" value="true"/>
+        default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true" />
     </module>
   </module>
 </module>

--- a/checks.xml
+++ b/checks.xml
@@ -319,7 +319,7 @@
                value="^@return the *|^This method returns |^A [{]@code [_a-zA-Z0-9]+[}]( is a )"/>
     </module> -->
     <module name="JavadocParagraph">
-      <property name="allowNewlineParagraph" value="true"/>
+      <property name="allowNewlineParagraph" value="false"/>
     </module>
     <module name="JavadocStyle">
       <property name="checkFirstSentence" value="false"/>

--- a/src/main/java/frc/lib/math/Axis.java
+++ b/src/main/java/frc/lib/math/Axis.java
@@ -1,0 +1,70 @@
+package frc.lib.math;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+
+public class Axis {
+
+    private double xDir;
+    private double yDir;
+
+
+    public Axis(double xDir, double yDir) {
+        setDirectionImpl(xDir, yDir);
+    }
+
+    public static Axis fromRotation(Rotation2d rot) {
+        return new Axis(rot.getCos(), rot.getSin());
+    }
+
+    public void setFromRotation(Rotation2d rot) {
+        setDirectionImpl(rot.getCos(), rot.getSin());
+    }
+
+    public Axis unaryMinus() {
+        return new Axis(-xDir, -yDir);
+    }
+
+    public double getX() {
+        return xDir;
+    }
+
+    public double getY() {
+        return yDir;
+    }
+
+    public void setDirection(double xDir, double yDir) {
+        setDirectionImpl(xDir, yDir);
+    }
+
+    private void setDirectionImpl(double xDir, double yDir) {
+        double norm = Math.hypot(xDir, yDir);
+        this.xDir = xDir / norm;
+        this.yDir = yDir / norm;
+    }
+
+    public double dot(Translation2d point) {
+        return this.xDir * point.getX() + this.yDir * point.getY();
+    }
+
+    public Interval project(Translation2d[] points) {
+        double v = 0.0;
+        Translation2d p = points[0];
+        double min = this.dot(p);
+        double max = min;
+
+        for (int i = 1; i < points.length; i++) {
+            p = points[i];
+            v = this.dot(p);
+
+            if (v < min) {
+                min = v;
+            } else if (v > max) {
+                max = v;
+            }
+        }
+
+        return new Interval(min, max);
+    }
+
+}

--- a/src/main/java/frc/lib/math/Axis.java
+++ b/src/main/java/frc/lib/math/Axis.java
@@ -3,36 +3,52 @@ package frc.lib.math;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 
+/** Represents an axis. */
 public class Axis {
 
     private double xDir;
     private double yDir;
 
-
+    /** Create new axis with a given direction. Either xDir or yDir must be non-zero. */
     public Axis(double xDir, double yDir) {
         setDirectionImpl(xDir, yDir);
     }
 
+    /** Create an axis with the same direction as the given rotation. */
     public static Axis fromRotation(Rotation2d rot) {
         return new Axis(rot.getCos(), rot.getSin());
     }
 
+    /** Set axis direction to the same direction as the given rotation. */
     public void setFromRotation(Rotation2d rot) {
         setDirectionImpl(rot.getCos(), rot.getSin());
     }
 
+    /**
+     * Get opposite direction. Is equivalent as far as the definition of an axis is concerned, but
+     * for implementation purposes, has a negative direction.
+     */
     public Axis unaryMinus() {
         return new Axis(-xDir, -yDir);
     }
 
+    /**
+     * Get the X direction.
+     */
     public double getX() {
         return xDir;
     }
 
+    /**
+     * Get the Y direction.
+     */
     public double getY() {
         return yDir;
     }
 
+    /**
+     * Set the direction. Either xDir or yDir must be non-zero.
+     */
     public void setDirection(double xDir, double yDir) {
         setDirectionImpl(xDir, yDir);
     }
@@ -43,10 +59,14 @@ public class Axis {
         this.yDir = yDir / norm;
     }
 
+    /**
+     * Get the dot product between this direction and a given point.
+     */
     public double dot(Translation2d point) {
         return this.xDir * point.getX() + this.yDir * point.getY();
     }
 
+    /** Project multiple points onto this axis. */
     public Interval project(Translation2d[] points) {
         double v = 0.0;
         Translation2d p = points[0];

--- a/src/main/java/frc/lib/math/ConvexShape.java
+++ b/src/main/java/frc/lib/math/ConvexShape.java
@@ -1,0 +1,21 @@
+package frc.lib.math;
+
+import edu.wpi.first.math.geometry.Translation2d;
+
+/** Represents a convex shape for the purpose of separating axis solving. */
+public interface ConvexShape {
+
+    /** Get the {@link Axis axes} of this {@link ConvexShape}. */
+    public Axis[] getAxes();
+
+    /**
+     * Get the {@link Interval} of this {@link ConvexShape} projected onto the given {@link Axis}.
+     */
+    public Interval project(Axis axis);
+
+    /**
+     * Get the center of this {@link ConvexShape}.
+     */
+    public Translation2d getCenter();
+
+}

--- a/src/main/java/frc/lib/math/Hexagon.java
+++ b/src/main/java/frc/lib/math/Hexagon.java
@@ -5,6 +5,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import frc.lib.util.viz.Drawable;
 
+/** A static hexagon shape. */
 public class Hexagon implements ConvexShape, Drawable {
 
     private final Axis[] axes = new Axis[] {Axis.fromRotation(Rotation2d.kZero),
@@ -16,6 +17,7 @@ public class Hexagon implements ConvexShape, Drawable {
     private final Translation2d center;
     private final String name;
 
+    /** A static hexagon shape. */
     public Hexagon(String name, Translation2d center, double radius, Rotation2d offset) {
         this.name = name;
         this.center = center;
@@ -47,6 +49,7 @@ public class Hexagon implements ConvexShape, Drawable {
         Logger.recordOutput(name, vertices);
     }
 
+    /** Returns true if `p` is inside this hexagon. */
     public boolean contains(Translation2d p) {
         int size = this.vertices.length;
         Translation2d p1 = this.vertices[size - 1];

--- a/src/main/java/frc/lib/math/Hexagon.java
+++ b/src/main/java/frc/lib/math/Hexagon.java
@@ -1,0 +1,84 @@
+package frc.lib.math;
+
+import org.littletonrobotics.junction.Logger;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import frc.lib.util.viz.Drawable;
+
+public class Hexagon implements ConvexShape, Drawable {
+
+    private final Axis[] axes = new Axis[] {Axis.fromRotation(Rotation2d.kZero),
+        Axis.fromRotation(Rotation2d.fromDegrees(60)),
+        Axis.fromRotation(Rotation2d.fromDegrees(120))};
+
+    private final Translation2d[] vertices;
+
+    private final Translation2d center;
+    private final String name;
+
+    public Hexagon(String name, Translation2d center, double radius, Rotation2d offset) {
+        this.name = name;
+        this.center = center;
+        this.vertices = new Translation2d[7];
+        for (int i = 0; i < 6; i++) {
+            Rotation2d rot = offset.plus(Rotation2d.fromRotations(i / 6.0));
+            this.vertices[i] = center.plus(new Translation2d(radius, rot));
+        }
+        this.vertices[6] = this.vertices[0];
+    }
+
+    @Override
+    public Axis[] getAxes() {
+        return axes;
+    }
+
+    @Override
+    public Interval project(Axis axis) {
+        return axis.project(this.vertices);
+    }
+
+    @Override
+    public Translation2d getCenter() {
+        return this.center;
+    }
+
+    @Override
+    public void draw() {
+        Logger.recordOutput(name, vertices);
+    }
+
+    public boolean contains(Translation2d p) {
+        int size = this.vertices.length;
+        Translation2d p1 = this.vertices[size - 1];
+        Translation2d p2 = this.vertices[0];
+
+        double last = getLocation(p, p1, p2);
+        for (int i = 0; i < size - 1; i++) {
+            p1 = p2;
+            p2 = this.vertices[i + 1];
+
+            double location = getLocation(p, p1, p2);
+
+            if (location == 0) {
+                return false;
+            }
+
+            if (last * location < 0) {
+                return false;
+            }
+
+            if (Math.abs(location) > 1e-5) {
+                last = location;
+            }
+        }
+
+        return true;
+    }
+
+    private static double getLocation(Translation2d point, Translation2d linePoint1,
+        Translation2d linePoint2) {
+        return (linePoint2.getX() - linePoint1.getX()) * (point.getY() - linePoint1.getY())
+            - (point.getX() - linePoint1.getX()) * (linePoint2.getY() - linePoint1.getY());
+    }
+
+}

--- a/src/main/java/frc/lib/math/Interval.java
+++ b/src/main/java/frc/lib/math/Interval.java
@@ -1,0 +1,47 @@
+package frc.lib.math;
+
+public class Interval {
+
+    private double min;
+    private double max;
+
+    public Interval(double min, double max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public double getMin() {
+        return min;
+    }
+
+    public void setMin(double min) {
+        this.min = min;
+    }
+
+    public double getMax() {
+        return max;
+    }
+
+    public void setMax(double max) {
+        this.max = max;
+    }
+
+
+
+    public boolean overlaps(Interval other) {
+        return !(this.min > other.max || other.min > this.max);
+    }
+
+    public double getOverlap(Interval other) {
+        // make sure they overlap
+        if (this.overlaps(other)) {
+            return Math.min(this.max, other.max) - Math.max(this.min, other.min);
+        }
+        return 0;
+    }
+
+    public boolean contains(Interval other) {
+        return other.min > this.min && other.max < this.max;
+    }
+
+}

--- a/src/main/java/frc/lib/math/Interval.java
+++ b/src/main/java/frc/lib/math/Interval.java
@@ -1,37 +1,43 @@
 package frc.lib.math;
 
+/** A one-dimensional range. */
 public class Interval {
 
     private double min;
     private double max;
 
+    /** A one-dimensional range. */
     public Interval(double min, double max) {
         this.min = min;
         this.max = max;
     }
 
+    /** Get lower extent of the range. */
     public double getMin() {
         return min;
     }
 
+    /** Set lower extent of the range. */
     public void setMin(double min) {
         this.min = min;
     }
 
+    /** Get upper extent of the range. */
     public double getMax() {
         return max;
     }
 
+    /** Set upper extent of the range. */
     public void setMax(double max) {
         this.max = max;
     }
 
-
-
+    /** Get if two intervals share some common subset. */
     public boolean overlaps(Interval other) {
         return !(this.min > other.max || other.min > this.max);
     }
 
+    /** Get length of common subset. */
     public double getOverlap(Interval other) {
         // make sure they overlap
         if (this.overlaps(other)) {
@@ -40,6 +46,7 @@ public class Interval {
         return 0;
     }
 
+    /** Get if `other` is completely contained by this range. */
     public boolean contains(Interval other) {
         return other.min > this.min && other.max < this.max;
     }

--- a/src/main/java/frc/lib/math/Line.java
+++ b/src/main/java/frc/lib/math/Line.java
@@ -1,0 +1,84 @@
+package frc.lib.math;
+
+import static edu.wpi.first.units.Units.Meters;
+import org.littletonrobotics.junction.Logger;
+import edu.wpi.first.math.geometry.Translation2d;
+import frc.lib.util.viz.Drawable;
+import frc.robot.FieldConstants;
+
+/** Represents a line in 2d space. Uses Ax + By + c = 0 representation. */
+public class Line implements Drawable {
+
+    public double a;
+    public double b;
+    public double c;
+    public String name;
+
+    public Line(String name, double a, double b, double c) {
+        this.name = name;
+        this.a = a;
+        this.b = b;
+        this.c = c;
+    }
+
+    private static final double minX = -20.0;
+    private static final double maxX = FieldConstants.fieldLength.in(Meters) + 20.0;
+    private static final double minY = -20.0;
+    private static final double maxY = FieldConstants.fieldWidth.in(Meters) + 20.0;
+
+    @Override
+    public void draw() {
+        if (a == 0 && b == 0) {
+            throw new IllegalArgumentException("a and b cannot simultaneously be zero!");
+        } else if (b == 0) {
+            double x = -c / a;
+            Logger.recordOutput(name,
+                new Translation2d[] {new Translation2d(x, minY), new Translation2d(x, maxY)});
+        } else if (a == 0) {
+            double y = -c / b;
+            Logger.recordOutput(name,
+                new Translation2d[] {new Translation2d(minX, y), new Translation2d(maxX, y)});
+        } else {
+            double x1 = minX;
+            double y1 = (-c - a * x1) / b;
+            if (y1 > maxY) {
+                y1 = maxY;
+                x1 = (-c - b * y1) / a;
+            } else if (y1 < minY) {
+                y1 = minY;
+                x1 = (-c - b * y1) / a;
+            }
+            double x2 = maxX;
+            double y2 = (-c - a * x2) / b;
+            if (y2 > maxY) {
+                y2 = maxY;
+                x2 = (-c - b * y2) / a;
+            } else if (y2 < minY) {
+                y2 = minY;
+                x2 = (-c - b * y2) / a;
+            }
+            Logger.recordOutput(name,
+                new Translation2d[] {new Translation2d(x1, y1), new Translation2d(x2, y2)});
+        }
+    }
+
+    public Translation2d intersection(Line other) {
+        double d = a * other.b - b * other.a;
+        if (d != 0) {
+            double dx = -c * other.b + b * other.c;
+            double dy = -a * other.c + c * other.a;
+            return new Translation2d(dx / d, dy / d);
+        } else {
+            return null;
+        }
+    }
+
+    public double parametricCoeff(Translation2d point) {
+        if (b == 0) {
+            return point.getY();
+        } else {
+            return point.getX() / b;
+        }
+    }
+
+}

--- a/src/main/java/frc/lib/math/Line.java
+++ b/src/main/java/frc/lib/math/Line.java
@@ -14,6 +14,7 @@ public class Line implements Drawable {
     public double c;
     public String name;
 
+    /** Represents a line in 2d space. Uses Ax + By + c = 0 representation. */
     public Line(String name, double a, double b, double c) {
         this.name = name;
         this.a = a;
@@ -62,6 +63,7 @@ public class Line implements Drawable {
         }
     }
 
+    /** Get intersection of two lines. Returns null if lines are parallel. */
     public Translation2d intersection(Line other) {
         double d = a * other.b - b * other.a;
         if (d != 0) {
@@ -70,14 +72,6 @@ public class Line implements Drawable {
             return new Translation2d(dx / d, dy / d);
         } else {
             return null;
-        }
-    }
-
-    public double parametricCoeff(Translation2d point) {
-        if (b == 0) {
-            return point.getY();
-        } else {
-            return point.getX() / b;
         }
     }
 

--- a/src/main/java/frc/lib/math/Penetration.java
+++ b/src/main/java/frc/lib/math/Penetration.java
@@ -3,43 +3,50 @@ package frc.lib.math;
 import org.littletonrobotics.junction.Logger;
 import frc.lib.util.viz.Drawable;
 
+/** Result type for {@link SeparatingAxis}. */
 public class Penetration implements Drawable {
 
     private final String name;
 
+    /** Result type for {@link SeparatingAxis}. */
     public Penetration(String name) {
         this.name = name;
     }
 
-    private double normalX = 0.0;
-    private double normalY = 0.0;
+    private double xDir = 0.0;
+    private double yDir = 0.0;
     private double depth = 0.0;
 
+    /** Set penetration direction. */
     public void setNormal(double x, double y) {
-        this.normalX = x;
-        this.normalY = y;
+        this.xDir = x;
+        this.yDir = y;
     }
 
+    /** Set penetration depth. */
     public void setDepth(double depth) {
         this.depth = depth;
     }
 
-    public double getNormalX() {
-        return normalX;
+    /** Get penetration direction x component. */
+    public double getXDir() {
+        return xDir;
     }
 
-    public double getNormalY() {
-        return normalY;
+    /** Get penetration direction y component. */
+    public double getYDir() {
+        return yDir;
     }
 
+    /** Get penetration depth. */
     public double getDepth() {
         return depth;
     }
 
     @Override
     public void draw() {
-        Logger.recordOutput(name + "/NormalX", normalX);
-        Logger.recordOutput(name + "/NormalY", normalY);
+        Logger.recordOutput(name + "/NormalX", xDir);
+        Logger.recordOutput(name + "/NormalY", yDir);
         Logger.recordOutput(name + "/Depth", depth);
     }
 

--- a/src/main/java/frc/lib/math/Penetration.java
+++ b/src/main/java/frc/lib/math/Penetration.java
@@ -1,0 +1,48 @@
+package frc.lib.math;
+
+import org.littletonrobotics.junction.Logger;
+import frc.lib.util.viz.Drawable;
+
+public class Penetration implements Drawable {
+
+    private final String name;
+
+    public Penetration(String name) {
+        this.name = name;
+    }
+
+    private double normalX = 0.0;
+    private double normalY = 0.0;
+    private double depth = 0.0;
+
+    public void setNormal(double x, double y) {
+        this.normalX = x;
+        this.normalY = y;
+    }
+
+    public void setDepth(double depth) {
+        this.depth = depth;
+    }
+
+    public double getNormalX() {
+        return normalX;
+    }
+
+    public double getNormalY() {
+        return normalY;
+    }
+
+    public double getDepth() {
+        return depth;
+    }
+
+    @Override
+    public void draw() {
+        Logger.recordOutput(name + "/NormalX", normalX);
+        Logger.recordOutput(name + "/NormalY", normalY);
+        Logger.recordOutput(name + "/Depth", depth);
+    }
+
+
+
+}

--- a/src/main/java/frc/lib/math/Penetration.java
+++ b/src/main/java/frc/lib/math/Penetration.java
@@ -45,8 +45,8 @@ public class Penetration implements Drawable {
 
     @Override
     public void draw() {
-        Logger.recordOutput(name + "/NormalX", xDir);
-        Logger.recordOutput(name + "/NormalY", yDir);
+        Logger.recordOutput(name + "/XDir", xDir);
+        Logger.recordOutput(name + "/YDir", yDir);
         Logger.recordOutput(name + "/Depth", depth);
     }
 

--- a/src/main/java/frc/lib/math/Rectangle.java
+++ b/src/main/java/frc/lib/math/Rectangle.java
@@ -6,6 +6,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import frc.lib.util.viz.Drawable;
 
+/** Rotating Rectangle Shape */
 public class Rectangle implements ConvexShape, Drawable {
 
     public final double width;
@@ -18,6 +19,7 @@ public class Rectangle implements ConvexShape, Drawable {
 
     private final String name;
 
+    /** Rotating Rectangle Shape */
     public Rectangle(String name, Pose2d pose, double length, double width) {
         this.name = name;
         this.pose = pose;
@@ -57,6 +59,7 @@ public class Rectangle implements ConvexShape, Drawable {
         return pose.getTranslation();
     }
 
+    /** Override rectangle pose. */
     public void setPose(Pose2d pose) {
         this.pose = pose;
     }

--- a/src/main/java/frc/lib/math/Rectangle.java
+++ b/src/main/java/frc/lib/math/Rectangle.java
@@ -1,0 +1,70 @@
+package frc.lib.math;
+
+import org.littletonrobotics.junction.Logger;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import frc.lib.util.viz.Drawable;
+
+public class Rectangle implements ConvexShape, Drawable {
+
+    public final double width;
+    public final double length;
+
+    private final Axis[] axes;
+    private final Translation2d[] vertices;
+
+    private Pose2d pose;
+
+    private final String name;
+
+    public Rectangle(String name, Pose2d pose, double length, double width) {
+        this.name = name;
+        this.pose = pose;
+        this.width = width;
+        this.length = length;
+        this.axes = new Axis[] {new Axis(1, 0), new Axis(1, 0)};
+        this.vertices = new Translation2d[5];
+    }
+
+    @Override
+    public Axis[] getAxes() {
+        axes[0].setFromRotation(pose.getRotation());
+        axes[1].setFromRotation(pose.getRotation().plus(Rotation2d.kCW_90deg));
+        return axes;
+    }
+
+    @Override
+    public Interval project(Axis axis) {
+        updateVertices();
+        return axis.project(vertices);
+    }
+
+    private void updateVertices() {
+        vertices[0] = pose.getTranslation()
+            .plus(new Translation2d(length / 2.0, width / 2.0).rotateBy(pose.getRotation()));
+        vertices[1] = pose.getTranslation()
+            .plus(new Translation2d(-length / 2.0, width / 2.0).rotateBy(pose.getRotation()));
+        vertices[2] = pose.getTranslation()
+            .plus(new Translation2d(-length / 2.0, -width / 2.0).rotateBy(pose.getRotation()));
+        vertices[3] = pose.getTranslation()
+            .plus(new Translation2d(length / 2.0, -width / 2.0).rotateBy(pose.getRotation()));
+        vertices[4] = vertices[0];
+    }
+
+    @Override
+    public Translation2d getCenter() {
+        return pose.getTranslation();
+    }
+
+    public void setPose(Pose2d pose) {
+        this.pose = pose;
+    }
+
+    @Override
+    public void draw() {
+        updateVertices();
+        Logger.recordOutput(name, vertices);
+    }
+
+}

--- a/src/main/java/frc/lib/math/SeparatingAxis.java
+++ b/src/main/java/frc/lib/math/SeparatingAxis.java
@@ -1,0 +1,91 @@
+package frc.lib.math;
+
+import edu.wpi.first.math.geometry.Translation2d;
+
+public class SeparatingAxis {
+
+    public static boolean solve(ConvexShape shape1, ConvexShape shape2, Penetration penetration) {
+
+        Axis n = null;
+        double overlap = Double.MAX_VALUE;
+
+        Axis[] axes1 = shape1.getAxes();
+        Axis[] axes2 = shape2.getAxes();
+
+        for (int i = 0; i < axes1.length; i++) {
+            Axis axis = axes1[i];
+            Interval intervalA = shape1.project(axis);
+            Interval intervalB = shape2.project(axis);
+
+            if (!intervalA.overlaps(intervalB)) {
+                return false;
+            } else {
+                double o = intervalA.getOverlap(intervalB);
+                // Check for containment
+                if (intervalA.contains(intervalB) || intervalB.contains(intervalA)) {
+                    // if containment exists then get the overlap plus the distance
+                    // to between the two end points that are the closest
+                    double max = Math.abs(intervalA.getMax() - intervalB.getMax());
+                    double min = Math.abs(intervalA.getMin() - intervalB.getMin());
+                    if (max > min) {
+                        // if the min differences is less than the max then we need
+                        // to flip the penetration axis
+                        axis = axis.unaryMinus();
+                        o += min;
+                    } else {
+                        o += max;
+                    }
+                }
+
+                if (o < overlap) {
+                    overlap = o;
+                    n = axis;
+                }
+            }
+        }
+
+        for (int i = 0; i < axes2.length; i++) {
+            Axis axis = axes2[i];
+            Interval intervalA = shape1.project(axis);
+            Interval intervalB = shape2.project(axis);
+
+            if (!intervalA.overlaps(intervalB)) {
+                return false;
+            } else {
+                double o = intervalA.getOverlap(intervalB);
+                // Check for containment
+                if (intervalA.contains(intervalB) || intervalB.contains(intervalA)) {
+                    // if containment exists then get the overlap plus the distance
+                    // to between the two end points that are the closest
+                    double max = Math.abs(intervalA.getMax() - intervalB.getMax());
+                    double min = Math.abs(intervalA.getMin() - intervalB.getMin());
+                    if (max > min) {
+                        // if the min differences is less than the max then we need
+                        // to flip the penetration axis
+                        axis = axis.unaryMinus();
+                        o += min;
+                    } else {
+                        o += max;
+                    }
+                }
+
+                if (o < overlap) {
+                    overlap = o;
+                    n = axis;
+                }
+            }
+        }
+
+        Translation2d c1 = shape1.getCenter();
+        Translation2d c2 = shape2.getCenter();
+        Translation2d cToc = c1.minus(c2);
+        if (n.dot(cToc) < 0) {
+            n = n.unaryMinus();
+        }
+
+        penetration.setNormal(n.getX(), n.getY());
+        penetration.setDepth(overlap);
+
+        return true;
+    }
+}

--- a/src/main/java/frc/lib/math/SeparatingAxis.java
+++ b/src/main/java/frc/lib/math/SeparatingAxis.java
@@ -2,8 +2,22 @@ package frc.lib.math;
 
 import edu.wpi.first.math.geometry.Translation2d;
 
-public class SeparatingAxis {
+/** Implementation of Separating Axis Theorem solver. */
+public final class SeparatingAxis {
 
+    private SeparatingAxis() {}
+
+    /**
+     * Solve the for the separating axis between two convex shape.
+     *
+     * @param shape1 resolving object. Result contains the transform for this shape to no longer be
+     *        penetrating.
+     * @param shape2 pseudo-static object. Result assumes this shape does not move.
+     * @param penetration out-parameter. Contains the direction and length of the minimum
+     *        translation vector.
+     * @return {@code true} if {@code shape1} and {@code shape2} are intersecting. If {@code false},
+     *         {@code penetration} is unmodified.
+     */
     public static boolean solve(ConvexShape shape1, ConvexShape shape2, Penetration penetration) {
 
         Axis n = null;

--- a/src/main/java/frc/lib/util/Tuples.java
+++ b/src/main/java/frc/lib/util/Tuples.java
@@ -1,0 +1,566 @@
+package frc.lib.util;
+
+
+/**
+ * Defines various tuple types for Java.
+ */
+public final class Tuples {
+    private Tuples() {}
+
+
+    /**
+     * A type that has a 1st element.
+     */
+    public static interface IValue1<T> {
+
+        /**
+         * Get the 1st element.
+         */
+        T _0();
+    }
+
+
+    /**
+     * A tuple of 1 elements.
+     */
+    public static final class Tuple1<T1> implements IValue1<T1> {
+        private final T1 v0;
+
+        /**
+         * Create a new 1-tuple.
+         */
+        public Tuple1(T1 v0) {
+            this.v0 = v0;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+    }
+
+
+    /**
+     * A type that has a 2nd element.
+     */
+    public static interface IValue2<T> {
+
+        /**
+         * Get the 2nd element.
+         */
+        T _1();
+    }
+
+
+    /**
+     * A tuple of 2 elements.
+     */
+    public static final class Tuple2<T1, T2> implements IValue1<T1>, IValue2<T2> {
+        private final T1 v0;
+        private final T2 v1;
+
+        /**
+         * Create a new 2-tuple.
+         */
+        public Tuple2(T1 v0, T2 v1) {
+            this.v0 = v0;
+            this.v1 = v1;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+        @Override
+        public T2 _1() {
+            return this.v1;
+        }
+
+    }
+
+
+    /**
+     * A type that has a 3rd element.
+     */
+    public static interface IValue3<T> {
+
+        /**
+         * Get the 3rd element.
+         */
+        T _2();
+    }
+
+
+    /**
+     * A tuple of 3 elements.
+     */
+    public static final class Tuple3<T1, T2, T3> implements IValue1<T1>, IValue2<T2>, IValue3<T3> {
+        private final T1 v0;
+        private final T2 v1;
+        private final T3 v2;
+
+        /**
+         * Create a new 3-tuple.
+         */
+        public Tuple3(T1 v0, T2 v1, T3 v2) {
+            this.v0 = v0;
+            this.v1 = v1;
+            this.v2 = v2;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+        @Override
+        public T2 _1() {
+            return this.v1;
+        }
+
+        @Override
+        public T3 _2() {
+            return this.v2;
+        }
+
+    }
+
+
+    /**
+     * A type that has a 4th element.
+     */
+    public static interface IValue4<T> {
+
+        /**
+         * Get the 4th element.
+         */
+        T _3();
+    }
+
+
+    /**
+     * A tuple of 4 elements.
+     */
+    public static final class Tuple4<T1, T2, T3, T4>
+        implements IValue1<T1>, IValue2<T2>, IValue3<T3>, IValue4<T4> {
+        private final T1 v0;
+        private final T2 v1;
+        private final T3 v2;
+        private final T4 v3;
+
+        /**
+         * Create a new 4-tuple.
+         */
+        public Tuple4(T1 v0, T2 v1, T3 v2, T4 v3) {
+            this.v0 = v0;
+            this.v1 = v1;
+            this.v2 = v2;
+            this.v3 = v3;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+        @Override
+        public T2 _1() {
+            return this.v1;
+        }
+
+        @Override
+        public T3 _2() {
+            return this.v2;
+        }
+
+        @Override
+        public T4 _3() {
+            return this.v3;
+        }
+
+    }
+
+
+    /**
+     * A type that has a 5th element.
+     */
+    public static interface IValue5<T> {
+
+        /**
+         * Get the 5th element.
+         */
+        T _4();
+    }
+
+
+    /**
+     * A tuple of 5 elements.
+     */
+    public static final class Tuple5<T1, T2, T3, T4, T5>
+        implements IValue1<T1>, IValue2<T2>, IValue3<T3>, IValue4<T4>, IValue5<T5> {
+        private final T1 v0;
+        private final T2 v1;
+        private final T3 v2;
+        private final T4 v3;
+        private final T5 v4;
+
+        /**
+         * Create a new 5-tuple.
+         */
+        public Tuple5(T1 v0, T2 v1, T3 v2, T4 v3, T5 v4) {
+            this.v0 = v0;
+            this.v1 = v1;
+            this.v2 = v2;
+            this.v3 = v3;
+            this.v4 = v4;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+        @Override
+        public T2 _1() {
+            return this.v1;
+        }
+
+        @Override
+        public T3 _2() {
+            return this.v2;
+        }
+
+        @Override
+        public T4 _3() {
+            return this.v3;
+        }
+
+        @Override
+        public T5 _4() {
+            return this.v4;
+        }
+
+    }
+
+
+    /**
+     * A type that has a 6th element.
+     */
+    public static interface IValue6<T> {
+
+        /**
+         * Get the 6th element.
+         */
+        T _5();
+    }
+
+
+    /**
+     * A tuple of 6 elements.
+     */
+    public static final class Tuple6<T1, T2, T3, T4, T5, T6>
+        implements IValue1<T1>, IValue2<T2>, IValue3<T3>, IValue4<T4>, IValue5<T5>, IValue6<T6> {
+        private final T1 v0;
+        private final T2 v1;
+        private final T3 v2;
+        private final T4 v3;
+        private final T5 v4;
+        private final T6 v5;
+
+        /**
+         * Create a new 6-tuple.
+         */
+        public Tuple6(T1 v0, T2 v1, T3 v2, T4 v3, T5 v4, T6 v5) {
+            this.v0 = v0;
+            this.v1 = v1;
+            this.v2 = v2;
+            this.v3 = v3;
+            this.v4 = v4;
+            this.v5 = v5;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+        @Override
+        public T2 _1() {
+            return this.v1;
+        }
+
+        @Override
+        public T3 _2() {
+            return this.v2;
+        }
+
+        @Override
+        public T4 _3() {
+            return this.v3;
+        }
+
+        @Override
+        public T5 _4() {
+            return this.v4;
+        }
+
+        @Override
+        public T6 _5() {
+            return this.v5;
+        }
+
+    }
+
+
+    /**
+     * A type that has a 7th element.
+     */
+    public static interface IValue7<T> {
+
+        /**
+         * Get the 7th element.
+         */
+        T _6();
+    }
+
+
+    /**
+     * A tuple of 7 elements.
+     */
+    public static final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements IValue1<T1>,
+        IValue2<T2>, IValue3<T3>, IValue4<T4>, IValue5<T5>, IValue6<T6>, IValue7<T7> {
+        private final T1 v0;
+        private final T2 v1;
+        private final T3 v2;
+        private final T4 v3;
+        private final T5 v4;
+        private final T6 v5;
+        private final T7 v6;
+
+        /**
+         * Create a new 7-tuple.
+         */
+        public Tuple7(T1 v0, T2 v1, T3 v2, T4 v3, T5 v4, T6 v5, T7 v6) {
+            this.v0 = v0;
+            this.v1 = v1;
+            this.v2 = v2;
+            this.v3 = v3;
+            this.v4 = v4;
+            this.v5 = v5;
+            this.v6 = v6;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+        @Override
+        public T2 _1() {
+            return this.v1;
+        }
+
+        @Override
+        public T3 _2() {
+            return this.v2;
+        }
+
+        @Override
+        public T4 _3() {
+            return this.v3;
+        }
+
+        @Override
+        public T5 _4() {
+            return this.v4;
+        }
+
+        @Override
+        public T6 _5() {
+            return this.v5;
+        }
+
+        @Override
+        public T7 _6() {
+            return this.v6;
+        }
+
+    }
+
+
+    /**
+     * A type that has a 8th element.
+     */
+    public static interface IValue8<T> {
+
+        /**
+         * Get the 8th element.
+         */
+        T _7();
+    }
+
+
+    /**
+     * A tuple of 8 elements.
+     */
+    public static final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements IValue1<T1>,
+        IValue2<T2>, IValue3<T3>, IValue4<T4>, IValue5<T5>, IValue6<T6>, IValue7<T7>, IValue8<T8> {
+        private final T1 v0;
+        private final T2 v1;
+        private final T3 v2;
+        private final T4 v3;
+        private final T5 v4;
+        private final T6 v5;
+        private final T7 v6;
+        private final T8 v7;
+
+        /**
+         * Create a new 8-tuple.
+         */
+        public Tuple8(T1 v0, T2 v1, T3 v2, T4 v3, T5 v4, T6 v5, T7 v6, T8 v7) {
+            this.v0 = v0;
+            this.v1 = v1;
+            this.v2 = v2;
+            this.v3 = v3;
+            this.v4 = v4;
+            this.v5 = v5;
+            this.v6 = v6;
+            this.v7 = v7;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+        @Override
+        public T2 _1() {
+            return this.v1;
+        }
+
+        @Override
+        public T3 _2() {
+            return this.v2;
+        }
+
+        @Override
+        public T4 _3() {
+            return this.v3;
+        }
+
+        @Override
+        public T5 _4() {
+            return this.v4;
+        }
+
+        @Override
+        public T6 _5() {
+            return this.v5;
+        }
+
+        @Override
+        public T7 _6() {
+            return this.v6;
+        }
+
+        @Override
+        public T8 _7() {
+            return this.v7;
+        }
+
+    }
+
+
+    /**
+     * A type that has a 9th element.
+     */
+    public static interface IValue9<T> {
+
+        /**
+         * Get the 9th element.
+         */
+        T _8();
+    }
+
+
+    /**
+     * A tuple of 9 elements.
+     */
+    public static final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>
+        implements IValue1<T1>, IValue2<T2>, IValue3<T3>, IValue4<T4>, IValue5<T5>, IValue6<T6>,
+        IValue7<T7>, IValue8<T8>, IValue9<T9> {
+        private final T1 v0;
+        private final T2 v1;
+        private final T3 v2;
+        private final T4 v3;
+        private final T5 v4;
+        private final T6 v5;
+        private final T7 v6;
+        private final T8 v7;
+        private final T9 v8;
+
+        /**
+         * Create a new 9-tuple.
+         */
+        public Tuple9(T1 v0, T2 v1, T3 v2, T4 v3, T5 v4, T6 v5, T7 v6, T8 v7, T9 v8) {
+            this.v0 = v0;
+            this.v1 = v1;
+            this.v2 = v2;
+            this.v3 = v3;
+            this.v4 = v4;
+            this.v5 = v5;
+            this.v6 = v6;
+            this.v7 = v7;
+            this.v8 = v8;
+        }
+
+        @Override
+        public T1 _0() {
+            return this.v0;
+        }
+
+        @Override
+        public T2 _1() {
+            return this.v1;
+        }
+
+        @Override
+        public T3 _2() {
+            return this.v2;
+        }
+
+        @Override
+        public T4 _3() {
+            return this.v3;
+        }
+
+        @Override
+        public T5 _4() {
+            return this.v4;
+        }
+
+        @Override
+        public T6 _5() {
+            return this.v5;
+        }
+
+        @Override
+        public T7 _6() {
+            return this.v6;
+        }
+
+        @Override
+        public T8 _7() {
+            return this.v7;
+        }
+
+        @Override
+        public T9 _8() {
+            return this.v8;
+        }
+
+    }
+
+}

--- a/src/main/java/frc/lib/util/viz/Drawable.java
+++ b/src/main/java/frc/lib/util/viz/Drawable.java
@@ -1,7 +1,9 @@
 package frc.lib.util.viz;
 
+/** Something that can be drawn to AdvantageScope. */
 public interface Drawable {
 
+    /** Draw to AdvantageScope */
     public void draw();
 
     // TODO maybe layout stuff here?

--- a/src/main/java/frc/lib/util/viz/Drawable.java
+++ b/src/main/java/frc/lib/util/viz/Drawable.java
@@ -1,0 +1,9 @@
+package frc.lib.util.viz;
+
+public interface Drawable {
+
+    public void draw();
+
+    // TODO maybe layout stuff here?
+
+}

--- a/src/main/java/frc/lib/util/viz/FieldViz.java
+++ b/src/main/java/frc/lib/util/viz/FieldViz.java
@@ -4,7 +4,7 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import frc.lib.util.ScoringLocation;
 
 /** Visualization for the whole field */
-public class FieldViz {
+public class FieldViz implements Drawable {
 
     /** Put coral on the reef */
     public void scoreCoral(Alliance alliance, ScoringLocation.CoralLocation branch,
@@ -20,6 +20,11 @@ public class FieldViz {
     /** Put algae in the processor */
     public void scoreAlgaeInProcessor(Alliance alliance, double yPos) {
         // TODO
+    }
+
+    @Override
+    public void draw() {
+
     }
 
 }

--- a/src/main/java/frc/lib/util/viz/Viz2025.java
+++ b/src/main/java/frc/lib/util/viz/Viz2025.java
@@ -14,7 +14,7 @@ import edu.wpi.first.units.measure.Distance;
 import frc.robot.Constants;
 
 /** Visualization of the 2025 Robot */
-public class Viz2025 {
+public class Viz2025 implements Drawable {
 
     private final FieldViz fieldViz;
     private final String prefix;
@@ -98,6 +98,7 @@ public class Viz2025 {
     }
 
     /** Publish all values to Logger */
+    @Override
     public void draw() {
         if (elevatorHeight > 0.1) {
             algaeDropped = true;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -209,11 +209,14 @@ public final class Constants {
         }
 
         public static final Mass robotMass = Pounds.of(120.0);
+        public static final Distance bumperFront = Inches.of(20.0);
+        public static final Distance bumperRight = Inches.of(20.0);
 
         /** Get config for Maple-Sim. */
         public static DriveTrainSimulationConfig getMapleConfig() {
             return DriveTrainSimulationConfig.Default().withRobotMass(robotMass)
                 .withGyro(COTS.ofNav2X()).withCustomModuleTranslations(moduleTranslations)
+                .withBumperSize(bumperFront.times(2), bumperRight.times(2))
                 .withSwerveModule(new SwerveModuleSimulationConfig(ModuleConstants.driveMotor,
                     ModuleConstants.angleMotor, ModuleConstants.driveReduction,
                     ModuleConstants.angleReduction, ModuleConstants.driveFrictionVoltage,
@@ -254,5 +257,13 @@ public final class Constants {
 
         public static final double zMargin = 0.75;
         public static final double fieldBorderMargin = 0.5;
+    }
+
+    /** State Estimator Constants */
+    public static class StateEstimator {
+        public static final boolean keepInField = true;
+        public static final boolean keepOutOfReefs = true;
+        public static final double visionTrust = 0.02;
+        public static final double visionTrustRotation = 200.0;
     }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -17,6 +17,8 @@ import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.ctre.phoenix6.signals.SensorDirectionValue;
 import com.studica.frc.AHRS.NavXComType;
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation2d;
@@ -233,11 +235,17 @@ public final class Constants {
     /** Vision Constants */
     public static class Vision {
 
+        public static final AprilTagFieldLayout fieldLayout =
+            AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+
         /** Constants for an individual camera. */
         public static final record CameraConstants(String name, int height, int width,
             Rotation2d horizontalFieldOfView, Frequency framesPerSecond, Time latencyAvg,
             Time latencyStdDev, double calibErrorAvg, double calibErrorStdDev,
             Transform3d robotToCamera) {
+            public double centerPixelYawRads() {
+                return robotToCamera.getRotation().getZ();
+            }
         }
 
         public static final CameraConstants[] cameras = new CameraConstants[] {

--- a/src/main/java/frc/robot/FieldConstants.java
+++ b/src/main/java/frc/robot/FieldConstants.java
@@ -1,0 +1,81 @@
+package frc.robot;
+
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Meters;
+import java.util.stream.IntStream;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.units.measure.Distance;
+
+/**
+ * Contains various field dimensions and useful reference points. All units are in meters and poses
+ * have a blue alliance origin.
+ */
+public class FieldConstants {
+
+    public static final Distance fieldLength = Inches.of(690.876);
+    public static final Distance fieldWidth = Inches.of(317);
+    /** Measured from the inside of starting line */
+    public static final Distance startingLineX = Inches.of(299.438);
+
+    /** Barge Constants */
+    public static class Barge {
+        public static final Translation2d farCage =
+            new Translation2d(Units.inchesToMeters(345.428), Units.inchesToMeters(286.779));
+        public static final Translation2d middleCage =
+            new Translation2d(Units.inchesToMeters(345.428), Units.inchesToMeters(242.855));
+        public static final Translation2d closeCage =
+            new Translation2d(Units.inchesToMeters(345.428), Units.inchesToMeters(199.947));
+
+        // Measured from floor to bottom of cage
+        public static final Distance deepHeight = Inches.of(3.125);
+        public static final Distance shallowHeight = Inches.of(30.125);
+    }
+
+    /** Coral Station Constants */
+    public static class CoralStation {
+
+        public static final Translation2d rightFarCorner =
+            new Translation2d(Units.inchesToMeters(67.778), 0);
+        public static final Translation2d rightCloseCorner =
+            new Translation2d(0, Units.inchesToMeters(49.875));
+
+        public static final double rightM = (rightFarCorner.getY() - rightCloseCorner.getY())
+            / (rightFarCorner.getX() - rightCloseCorner.getX());
+        public static final double rightB = rightFarCorner.getY() - rightM * rightFarCorner.getX();
+
+        public static final Translation2d leftFarCorner =
+            new Translation2d(rightFarCorner.getX(), fieldWidth.in(Meters) - rightFarCorner.getY());
+        public static final Translation2d leftCloseCorner = new Translation2d(
+            rightCloseCorner.getX(), fieldWidth.in(Meters) - rightCloseCorner.getY());
+
+        public static final double leftM = (leftFarCorner.getY() - leftCloseCorner.getY())
+            / (leftFarCorner.getX() - leftCloseCorner.getX());
+        public static final double leftB = leftFarCorner.getY() - leftM * leftFarCorner.getX();
+
+    }
+
+    /** Reef Constants */
+    public static class Reef {
+
+        public static final Translation2d center =
+            new Translation2d(Units.inchesToMeters(176.746), Units.inchesToMeters(158.501));
+
+        public static final Distance inscribedRadius = Inches.of(65.491 / 2);
+        public static final Distance circumscribedRadius =
+            Meters.of(inscribedRadius.in(Meters) / Math.cos(Math.PI / 6));
+
+        public static final Translation2d[] reefVertices = IntStream.range(0, 6).mapToObj(i -> {
+            double y = center.getY() + Math.cos(Math.PI / 3.0 * i) * circumscribedRadius.in(Meters);
+            double x = center.getX() + Math.sin(Math.PI / 3.0 * i) * circumscribedRadius.in(Meters);
+            return new Translation2d(x, y);
+        }).toArray(Translation2d[]::new);
+
+        // public static final Axis[] collisionAxes = new Axis[]
+        // {Axis.fromRotation(Rotation2d.kZero),
+        // Axis.fromRotation(Rotation2d.fromDegrees(60)),
+        // Axis.fromRotation(Rotation2d.fromDegrees(120)),};
+
+    }
+
+}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -123,6 +123,10 @@ public class RobotContainer {
                 return timer.hasElapsed(3.0);
             }
         });
+
+        driver.x().onTrue(new InstantCommand(() -> {
+            s_Swerve.resetOdometry(new Pose2d(7.24, 4.05, Rotation2d.kZero));
+        }));
     }
 
     /**
@@ -144,7 +148,7 @@ public class RobotContainer {
     /** Start simulation */
     public void startSimulation() {
         if (driveSimulation != null) {
-            SimulatedArena.getInstance().resetFieldForAuto();
+            // SimulatedArena.getInstance().resetFieldForAuto();
         }
     }
 

--- a/src/main/java/frc/robot/RobotState.java
+++ b/src/main/java/frc/robot/RobotState.java
@@ -1,9 +1,9 @@
 package frc.robot;
 
 import java.util.stream.Stream;
+import org.littletonrobotics.junction.Logger;
 import org.photonvision.targeting.PhotonPipelineResult;
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
-import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
@@ -22,8 +22,7 @@ public class RobotState {
     }
 
     private SwerveDrivePoseEstimator swerveOdometry = null;
-    private final AprilTagFieldLayout fieldLayout =
-        AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+
 
     public void init(SwerveModulePosition[] positions, Rotation2d gyroYaw) {
         swerveOdometry = new SwerveDrivePoseEstimator(Constants.Swerve.swerveKinematics, gyroYaw,
@@ -48,13 +47,17 @@ public class RobotState {
     /**
      * Add information from cameras.
      */
-    public void addVisionObservation(PhotonPipelineResult result, Transform3d robotToCamera) {
+    public void addVisionObservation(PhotonPipelineResult result, Transform3d robotToCamera,
+        int whichCamera) {
         if (result.multitagResult.isPresent()) {
             Transform3d best = result.multitagResult.get().estimatedPose.best;
-            Pose3d cameraPose = new Pose3d().plus(best).relativeTo(fieldLayout.getOrigin());
+            Pose3d cameraPose =
+                new Pose3d().plus(best).relativeTo(Constants.Vision.fieldLayout.getOrigin());
             Pose3d robotPose = cameraPose.plus(robotToCamera.inverse());
             Pose2d robotPose2d = robotPose.toPose2d();
-            swerveOdometry.addVisionMeasurement(robotPose2d, result.getTimestampSeconds());
+            Logger.recordOutput("State/GlobalVisionEstimate", robotPose);
+            swerveOdometry.addVisionMeasurement(robotPose2d, result.getTimestampSeconds(),
+                VecBuilder.fill(0.02, 0.02, 0.02));
         }
     }
 

--- a/src/main/java/frc/robot/RobotState.java
+++ b/src/main/java/frc/robot/RobotState.java
@@ -1,5 +1,6 @@
 package frc.robot;
 
+import static edu.wpi.first.units.Units.Meters;
 import java.util.stream.Stream;
 import org.littletonrobotics.junction.Logger;
 import org.photonvision.targeting.PhotonPipelineResult;
@@ -9,7 +10,12 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import frc.lib.math.Hexagon;
+import frc.lib.math.Penetration;
+import frc.lib.math.Rectangle;
+import frc.lib.math.SeparatingAxis;
 import frc.lib.util.viz.Viz2025;
 
 /** Primary Drivetrain State Estimator */
@@ -57,7 +63,9 @@ public class RobotState {
             Pose2d robotPose2d = robotPose.toPose2d();
             Logger.recordOutput("State/GlobalVisionEstimate", robotPose);
             swerveOdometry.addVisionMeasurement(robotPose2d, result.getTimestampSeconds(),
-                VecBuilder.fill(0.02, 0.02, 0.02));
+                VecBuilder.fill(Constants.StateEstimator.visionTrust,
+                    Constants.StateEstimator.visionTrust,
+                    Constants.StateEstimator.visionTrustRotation));
         }
     }
 
@@ -66,6 +74,7 @@ public class RobotState {
      */
     public void addSwerveObservation(SwerveModulePosition[] positions, Rotation2d gyroYaw) {
         swerveOdometry.update(gyroYaw, positions);
+        constrain(positions, gyroYaw);
         vis.setDrivetrainState(swerveOdometry.getEstimatedPosition(),
             Stream.of(positions).map(x -> x.angle).toArray(this::swerveRotationsArray));
     }
@@ -79,5 +88,201 @@ public class RobotState {
     private Rotation2d[] swerveRotationsArray(int _count) {
         return swerveRotations;
     }
+
+    private void constrain(SwerveModulePosition[] positions, Rotation2d gyroYaw) {
+        var original = getGlobalPoseEstimate();
+        double x = original.getX();
+        double y = original.getY();
+        double t = -original.getRotation().getRadians();
+
+        Translation2d[] bumpers = new Translation2d[5];
+        Translation2d[] tr = new Translation2d[4];
+        for (int i = 0; i < 4; i++) {
+            double theta = t + i * Math.PI / 2;
+            tr[i] = new Translation2d(
+                x + Math.cos(theta) * Constants.Swerve.bumperFront.in(Meters)
+                    + Math.sin(theta) * Constants.Swerve.bumperRight.in(Meters),
+                y - Math.sin(theta) * Constants.Swerve.bumperFront.in(Meters)
+                    + Math.cos(theta) * Constants.Swerve.bumperRight.in(Meters));
+            bumpers[i] = tr[i];
+        }
+        bumpers[4] = bumpers[0];
+
+        double dx = 0.0;
+        double dy = 0.0;
+
+        if (Constants.StateEstimator.keepInField) {
+
+            double maxY = FieldConstants.fieldWidth.in(Meters);
+            double maxX = FieldConstants.fieldLength.in(Meters);
+
+            for (int i = 0; i < 4; i++) {
+                double x1 = tr[i].getX();
+                double y1 = tr[i].getY();
+                double x2 = maxX - x1;
+
+                // Simple keep in rect
+                if (x1 < 0.0) {
+                    if (-x1 > Math.abs(dx)) {
+                        dx = -x1;
+                    }
+                } else if (x1 > maxX) {
+                    double mdx = x1 - maxX;
+                    if (mdx > Math.abs(dx)) {
+                        dx = -mdx;
+                    }
+                }
+                if (y1 < 0.0) {
+                    if (-y1 > Math.abs(dy)) {
+                        dy = -y1;
+                    }
+                } else if (y1 > maxY) {
+                    double mdy = y1 - maxY;
+                    if (mdy > Math.abs(dy)) {
+                        dy = -mdy;
+                    }
+                }
+
+                // Coral Stations
+
+                if (FieldConstants.CoralStation.rightM * x1
+                    + FieldConstants.CoralStation.rightB > y1) {
+                    double newM = -1.0 / FieldConstants.CoralStation.rightM;
+                    double newB = y1 - newM * x1;
+                    double newX = (newB - FieldConstants.CoralStation.rightB)
+                        / (FieldConstants.CoralStation.rightM - newM);
+                    double newY = newM * newX + newB;
+                    double newDx = (newX - x1);
+                    double newDy = (newY - y1);
+                    double newNormSqr = newDx * newDx + newDy * newDy;
+                    double oldNormSqr = dx * dx + dy * dy;
+                    if (newNormSqr > oldNormSqr) {
+                        dx = newDx;
+                        dy = newDy;
+                    }
+                } else if (FieldConstants.CoralStation.leftM * x1
+                    + FieldConstants.CoralStation.leftB < y1) {
+                    double newM = -1.0 / FieldConstants.CoralStation.leftM;
+                    double newB = y1 - newM * x1;
+                    double newX = (newB - FieldConstants.CoralStation.leftB)
+                        / (FieldConstants.CoralStation.leftM - newM);
+                    double newY = newM * newX + newB;
+                    double newDx = (newX - x1);
+                    double newDy = (newY - y1);
+                    double newNormSqr = newDx * newDx + newDy * newDy;
+                    double oldNormSqr = dx * dx + dy * dy;
+                    if (newNormSqr > oldNormSqr) {
+                        dx = newDx;
+                        dy = newDy;
+                    }
+                } else if (FieldConstants.CoralStation.rightM * x2
+                    + FieldConstants.CoralStation.rightB > y1) {
+                    double newM = -1.0 / FieldConstants.CoralStation.rightM;
+                    double newB = y1 - newM * x2;
+                    double newX = (newB - FieldConstants.CoralStation.rightB)
+                        / (FieldConstants.CoralStation.rightM - newM);
+                    double newY = newM * newX + newB;
+                    double newDx = (newX - x2);
+                    double newDy = (newY - y1);
+                    double newNormSqr = newDx * newDx + newDy * newDy;
+                    double oldNormSqr = dx * dx + dy * dy;
+                    if (newNormSqr > oldNormSqr) {
+                        dx = -newDx;
+                        dy = newDy;
+                    }
+                } else if (FieldConstants.CoralStation.leftM * x2
+                    + FieldConstants.CoralStation.leftB < y1) {
+                    double newM = -1.0 / FieldConstants.CoralStation.leftM;
+                    double newB = y1 - newM * x2;
+                    double newX = (newB - FieldConstants.CoralStation.leftB)
+                        / (FieldConstants.CoralStation.leftM - newM);
+                    double newY = newM * newX + newB;
+                    double newDx = (newX - x2);
+                    double newDy = (newY - y1);
+                    double newNormSqr = newDx * newDx + newDy * newDy;
+                    double oldNormSqr = dx * dx + dy * dy;
+                    if (newNormSqr > oldNormSqr) {
+                        dx = -newDx;
+                        dy = newDy;
+                    }
+                }
+            }
+        }
+
+        // Reef check
+
+        reef1.draw();
+        reef2.draw();
+        centerPost.draw();
+        robot.setPose(original);
+        robot.draw();
+
+        if (Constants.StateEstimator.keepOutOfReefs) {
+            Penetration penetration = new Penetration("ReefPen");
+            Translation2d[] sepResult =
+                new Translation2d[] {Translation2d.kZero, Translation2d.kZero};
+            if (SeparatingAxis.solve(robot, reef1, penetration)) {
+                sepResult[0] = robot.getCenter();
+                Translation2d offs = new Translation2d(penetration.getDepth(),
+                    new Rotation2d(penetration.getNormalX(), penetration.getNormalY()));
+                Translation2d resPos = robot.getCenter().plus(offs);
+                robotTest.setPose(new Pose2d(resPos, original.getRotation()));
+                sepResult[1] = robotTest.getCenter();
+                penetration.draw();
+
+                dx = offs.getX();
+                dy = offs.getY();
+            } else if (SeparatingAxis.solve(robot, reef2, penetration)) {
+                sepResult[0] = robot.getCenter();
+                Translation2d offs = new Translation2d(penetration.getDepth(),
+                    new Rotation2d(penetration.getNormalX(), penetration.getNormalY()));
+                Translation2d resPos = robot.getCenter().plus(offs);
+                robotTest.setPose(new Pose2d(resPos, original.getRotation()));
+                sepResult[1] = robotTest.getCenter();
+                penetration.draw();
+
+                dx = offs.getX();
+                dy = offs.getY();
+            } else if (SeparatingAxis.solve(robot, centerPost, penetration)) {
+                sepResult[0] = robot.getCenter();
+                Translation2d offs = new Translation2d(penetration.getDepth(),
+                    new Rotation2d(penetration.getNormalX(), penetration.getNormalY()));
+                Translation2d resPos = robot.getCenter().plus(offs);
+                robotTest.setPose(new Pose2d(resPos, original.getRotation()));
+                sepResult[1] = robotTest.getCenter();
+                penetration.draw();
+
+                dx = offs.getX();
+                dy = offs.getY();
+            } else {
+                robotTest.setPose(new Pose2d(-100, -100, Rotation2d.kZero));
+            }
+            robotTest.draw();
+
+            Logger.recordOutput("sepResult", sepResult);
+        }
+
+        // TODO
+
+        if (Math.abs(dx) > 0.01 || Math.abs(dy) > 0.01) {
+            resetPose(new Pose2d(x + dx, y + dy, original.getRotation()), positions, gyroYaw);
+            return;
+        }
+    }
+
+    private final Hexagon reef1 = new Hexagon("BlueReef", FieldConstants.Reef.center,
+        FieldConstants.Reef.circumscribedRadius.in(Meters), Rotation2d.fromDegrees(30));
+    private final Hexagon reef2 = new Hexagon("RedReef",
+        new Translation2d(FieldConstants.fieldLength.in(Meters) - FieldConstants.Reef.center.getX(),
+            FieldConstants.Reef.center.getY()),
+        FieldConstants.Reef.circumscribedRadius.in(Meters), Rotation2d.fromDegrees(30));
+    private final Rectangle centerPost = new Rectangle("CenterPost",
+        new Pose2d(new Translation2d(FieldConstants.fieldLength.in(Meters) / 2,
+            FieldConstants.fieldWidth.in(Meters) / 2), Rotation2d.kZero),
+        0.4, 0.4);
+    private final Rectangle robot = new Rectangle("Robot", new Pose2d(),
+        Constants.Swerve.bumperFront.in(Meters) * 2, Constants.Swerve.bumperRight.in(Meters) * 2);
+    private final Rectangle robotTest = new Rectangle("RobotTest", new Pose2d(),
+        Constants.Swerve.bumperFront.in(Meters) * 2, Constants.Swerve.bumperRight.in(Meters) * 2);
 
 }

--- a/src/main/java/frc/robot/RobotState.java
+++ b/src/main/java/frc/robot/RobotState.java
@@ -17,6 +17,7 @@ import frc.lib.math.Penetration;
 import frc.lib.math.Rectangle;
 import frc.lib.math.SeparatingAxis;
 import frc.lib.util.viz.Viz2025;
+import frc.robot.subsystems.swerve.Swerve;
 
 /** Primary Drivetrain State Estimator */
 public class RobotState {
@@ -29,10 +30,16 @@ public class RobotState {
 
     private SwerveDrivePoseEstimator swerveOdometry = null;
 
-
+    /**
+     * Initialize this {@link RobotState}. Should only be called once (usually from the
+     * {@link Swerve} constructor).
+     */
     public void init(SwerveModulePosition[] positions, Rotation2d gyroYaw) {
         swerveOdometry = new SwerveDrivePoseEstimator(Constants.Swerve.swerveKinematics, gyroYaw,
             positions, new Pose2d());
+        swerveOdometry.setVisionMeasurementStdDevs(VecBuilder.fill(
+            Constants.StateEstimator.visionTrust, Constants.StateEstimator.visionTrust,
+            Constants.StateEstimator.visionTrustRotation));
     }
 
     /**
@@ -62,10 +69,7 @@ public class RobotState {
             Pose3d robotPose = cameraPose.plus(robotToCamera.inverse());
             Pose2d robotPose2d = robotPose.toPose2d();
             Logger.recordOutput("State/GlobalVisionEstimate", robotPose);
-            swerveOdometry.addVisionMeasurement(robotPose2d, result.getTimestampSeconds(),
-                VecBuilder.fill(Constants.StateEstimator.visionTrust,
-                    Constants.StateEstimator.visionTrust,
-                    Constants.StateEstimator.visionTrustRotation));
+            swerveOdometry.addVisionMeasurement(robotPose2d, result.getTimestampSeconds());
         }
     }
 
@@ -224,7 +228,7 @@ public class RobotState {
             if (SeparatingAxis.solve(robot, reef1, penetration)) {
                 sepResult[0] = robot.getCenter();
                 Translation2d offs = new Translation2d(penetration.getDepth(),
-                    new Rotation2d(penetration.getNormalX(), penetration.getNormalY()));
+                    new Rotation2d(penetration.getXDir(), penetration.getYDir()));
                 Translation2d resPos = robot.getCenter().plus(offs);
                 robotTest.setPose(new Pose2d(resPos, original.getRotation()));
                 sepResult[1] = robotTest.getCenter();
@@ -235,7 +239,7 @@ public class RobotState {
             } else if (SeparatingAxis.solve(robot, reef2, penetration)) {
                 sepResult[0] = robot.getCenter();
                 Translation2d offs = new Translation2d(penetration.getDepth(),
-                    new Rotation2d(penetration.getNormalX(), penetration.getNormalY()));
+                    new Rotation2d(penetration.getXDir(), penetration.getYDir()));
                 Translation2d resPos = robot.getCenter().plus(offs);
                 robotTest.setPose(new Pose2d(resPos, original.getRotation()));
                 sepResult[1] = robotTest.getCenter();
@@ -246,7 +250,7 @@ public class RobotState {
             } else if (SeparatingAxis.solve(robot, centerPost, penetration)) {
                 sepResult[0] = robot.getCenter();
                 Translation2d offs = new Translation2d(penetration.getDepth(),
-                    new Rotation2d(penetration.getNormalX(), penetration.getNormalY()));
+                    new Rotation2d(penetration.getXDir(), penetration.getYDir()));
                 Translation2d resPos = robot.getCenter().plus(offs);
                 robotTest.setPose(new Pose2d(resPos, original.getRotation()));
                 sepResult[1] = robotTest.getCenter();

--- a/src/main/java/frc/robot/subsystems/vision/VisionSimPhoton.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSimPhoton.java
@@ -7,8 +7,6 @@ import org.ironmaple.simulation.drivesims.SwerveDriveSimulation;
 import org.photonvision.simulation.PhotonCameraSim;
 import org.photonvision.simulation.SimCameraProperties;
 import org.photonvision.simulation.VisionSystemSim;
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
-import edu.wpi.first.apriltag.AprilTagFields;
 import frc.robot.Constants;
 
 /** Simulation of vision using built-in PhotonVision simulator. */
@@ -30,8 +28,7 @@ public class VisionSimPhoton extends VisionReal {
         this.sim = sim;
         visionSim = new VisionSystemSim("main");
 
-        AprilTagFieldLayout tagLayout = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
-        visionSim.addAprilTags(tagLayout);
+        visionSim.addAprilTags(Constants.Vision.fieldLayout);
 
         for (int i = 0; i < constants.length; i++) {
             SimCameraProperties props = new SimCameraProperties();


### PR DESCRIPTION
State Estimator now keeps current estimate both
1. Inside the field
2. Outside of the reefs.

It does this through two processes (both can be turned off with a value in Constants)
1. Keeping inside the field simply checks if any of the corners are outside, and if so, moves them inside. It uses the perpendicular direction for solving which direction is "inside". Since there are no potential corners the bumper could hit longside on the perimeter of the field, this is sufficient.
2. Using the separating axis theorem as described in [this blog post from 2010](https://dyn4j.org/2010/01/sat/#sat-mtv) for the reefs. 

There are still some ways the estimator gets off track, including
1. Wheel slips in the open field. This PR fixes slips while stalling against a wall, but slips in the open field, usually from changing acceleration quickly, still result in a mismatch. This is observable in sim.
2. Sliding against a wall. The current collision response mechanism has no concept of friction, so the estimate will slide much better against the wall than the actual robot will (or the sim for that matter). 