### PR TITLE
Reduce Memory Usage

### DIFF
--- a/src/main/java/frc/lib/math/Axis.java
+++ b/src/main/java/frc/lib/math/Axis.java
@@ -1,7 +1,8 @@
 package frc.lib.math;
 
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Translation2d;
+import frc.lib.mut.MutableRotation2d;
+import frc.lib.mut.MutableTranslation2d;
 
 /** Represents an axis. */
 public class Axis {
@@ -21,6 +22,11 @@ public class Axis {
 
     /** Set axis direction to the same direction as the given rotation. */
     public void setFromRotation(Rotation2d rot) {
+        setDirectionImpl(rot.getCos(), rot.getSin());
+    }
+
+    /** Set axis direction to the same direction as the given rotation. */
+    public void setFromRotation(MutableRotation2d rot) {
         setDirectionImpl(rot.getCos(), rot.getSin());
     }
 
@@ -62,14 +68,18 @@ public class Axis {
     /**
      * Get the dot product between this direction and a given point.
      */
-    public double dot(Translation2d point) {
+    public double dot(MutableTranslation2d point) {
         return this.xDir * point.getX() + this.yDir * point.getY();
     }
 
     /** Project multiple points onto this axis. */
-    public Interval project(Translation2d[] points) {
+    public Interval project(MutableTranslation2d[] points) {
+        return project(points, new Interval(0.0, 0.0));
+    }
+
+    public Interval project(MutableTranslation2d[] points, Interval out) {
         double v = 0.0;
-        Translation2d p = points[0];
+        MutableTranslation2d p = points[0];
         double min = this.dot(p);
         double max = min;
 
@@ -84,7 +94,9 @@ public class Axis {
             }
         }
 
-        return new Interval(min, max);
+        out.setMin(min);
+        out.setMax(max);
+        return out;
     }
 
 }

--- a/src/main/java/frc/lib/math/ConvexShape.java
+++ b/src/main/java/frc/lib/math/ConvexShape.java
@@ -1,6 +1,6 @@
 package frc.lib.math;
 
-import edu.wpi.first.math.geometry.Translation2d;
+import frc.lib.mut.MutableTranslation2d;
 
 /** Represents a convex shape for the purpose of separating axis solving. */
 public interface ConvexShape {
@@ -16,6 +16,6 @@ public interface ConvexShape {
     /**
      * Get the center of this {@link ConvexShape}.
      */
-    public Translation2d getCenter();
+    public MutableTranslation2d getCenter();
 
 }

--- a/src/main/java/frc/lib/math/Penetration.java
+++ b/src/main/java/frc/lib/math/Penetration.java
@@ -1,6 +1,7 @@
 package frc.lib.math;
 
 import org.littletonrobotics.junction.Logger;
+import frc.lib.mut.MutableTranslation2d;
 import frc.lib.util.viz.Drawable;
 
 /** Result type for {@link SeparatingAxis}. */
@@ -41,6 +42,10 @@ public class Penetration implements Drawable {
     /** Get penetration depth. */
     public double getDepth() {
         return depth;
+    }
+
+    public MutableTranslation2d update(MutableTranslation2d out) {
+        return out.setXY(xDir * depth, yDir * depth);
     }
 
     @Override

--- a/src/main/java/frc/lib/math/Rectangle.java
+++ b/src/main/java/frc/lib/math/Rectangle.java
@@ -1,9 +1,13 @@
 package frc.lib.math;
 
+import java.util.stream.Stream;
 import org.littletonrobotics.junction.Logger;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import frc.lib.mut.MutablePose2d;
+import frc.lib.mut.MutableRotation2d;
+import frc.lib.mut.MutableTranslation2d;
 import frc.lib.util.viz.Drawable;
 
 /** Rotating Rectangle Shape */
@@ -13,61 +17,78 @@ public class Rectangle implements ConvexShape, Drawable {
     public final double length;
 
     private final Axis[] axes;
-    private final Translation2d[] vertices;
+    private final MutableTranslation2d[] vertices;
 
-    private Pose2d pose;
+    private MutablePose2d pose;
 
     private final String name;
 
     /** Rotating Rectangle Shape */
     public Rectangle(String name, Pose2d pose, double length, double width) {
         this.name = name;
-        this.pose = pose;
+        this.pose = new MutablePose2d(pose);
         this.width = width;
         this.length = length;
         this.axes = new Axis[] {new Axis(1, 0), new Axis(1, 0)};
-        this.vertices = new Translation2d[5];
+        this.vertices = new MutableTranslation2d[5];
+        for (int i = 0; i < 4; i++) {
+            vertices[i] = new MutableTranslation2d();
+        }
+        this.cornerValues = new double[] {length / 2.0, width / 2.0, -length / 2.0, width / 2.0,
+            -length / 2.0, -width / 2.0, length / 2.0, -width / 2.0};
     }
+
+    private MutableRotation2d tempRotation = new MutableRotation2d();
 
     @Override
     public Axis[] getAxes() {
         axes[0].setFromRotation(pose.getRotation());
-        axes[1].setFromRotation(pose.getRotation().plus(Rotation2d.kCW_90deg));
+        axes[1].setFromRotation(pose.getRotation().plus(Rotation2d.kCW_90deg, tempRotation));
         return axes;
     }
+
+    private final Interval tempInterval = new Interval(0, 0);
 
     @Override
     public Interval project(Axis axis) {
         updateVertices();
-        return axis.project(vertices);
+        return axis.project(vertices, tempInterval);
     }
 
+    private final MutableTranslation2d[] corners =
+        new MutableTranslation2d[] {new MutableTranslation2d(), new MutableTranslation2d(),
+            new MutableTranslation2d(), new MutableTranslation2d(),};
+
+    private final double[] cornerValues;
+
     private void updateVertices() {
-        vertices[0] = pose.getTranslation()
-            .plus(new Translation2d(length / 2.0, width / 2.0).rotateBy(pose.getRotation()));
-        vertices[1] = pose.getTranslation()
-            .plus(new Translation2d(-length / 2.0, width / 2.0).rotateBy(pose.getRotation()));
-        vertices[2] = pose.getTranslation()
-            .plus(new Translation2d(-length / 2.0, -width / 2.0).rotateBy(pose.getRotation()));
-        vertices[3] = pose.getTranslation()
-            .plus(new Translation2d(length / 2.0, -width / 2.0).rotateBy(pose.getRotation()));
+        for (int i = 0; i < 4; i++) {
+            corners[i].setXY(cornerValues[2 * i], cornerValues[2 * i] + 1)
+                .rotateBy(pose.getRotation(), corners[i]).plus(pose.getTranslation(), vertices[i]);
+        }
         vertices[4] = vertices[0];
     }
 
     @Override
-    public Translation2d getCenter() {
+    public MutableTranslation2d getCenter() {
         return pose.getTranslation();
     }
 
     /** Override rectangle pose. */
     public void setPose(Pose2d pose) {
-        this.pose = pose;
+        this.setPose(pose.getX(), pose.getY(), pose.getRotation().getRadians());
+    }
+
+    public void setPose(double x, double y, double radians) {
+        this.pose.getTranslation().setXY(x, y);
+        this.pose.getRotation().setRadians(radians);
     }
 
     @Override
     public void drawImpl() {
         updateVertices();
-        Logger.recordOutput(name, vertices);
+        Logger.recordOutput(name,
+            Stream.of(vertices).map((v) -> v.toImmutable()).toArray(Translation2d[]::new));
     }
 
 }

--- a/src/main/java/frc/lib/math/SeparatingAxis.java
+++ b/src/main/java/frc/lib/math/SeparatingAxis.java
@@ -1,6 +1,6 @@
 package frc.lib.math;
 
-import edu.wpi.first.math.geometry.Translation2d;
+import frc.lib.mut.MutableTranslation2d;
 
 /** Implementation of Separating Axis Theorem solver. */
 public final class SeparatingAxis {
@@ -90,9 +90,9 @@ public final class SeparatingAxis {
             }
         }
 
-        Translation2d c1 = shape1.getCenter();
-        Translation2d c2 = shape2.getCenter();
-        Translation2d cToc = c1.minus(c2);
+        MutableTranslation2d c1 = shape1.getCenter();
+        MutableTranslation2d c2 = shape2.getCenter();
+        MutableTranslation2d cToc = c1.minus(c2, tempTranslation);
         if (n.dot(cToc) < 0) {
             n = n.unaryMinus();
         }
@@ -102,4 +102,6 @@ public final class SeparatingAxis {
 
         return true;
     }
+
+    private static final MutableTranslation2d tempTranslation = new MutableTranslation2d();
 }

--- a/src/main/java/frc/lib/mut/MutablePose2d.java
+++ b/src/main/java/frc/lib/mut/MutablePose2d.java
@@ -1,0 +1,33 @@
+package frc.lib.mut;
+
+import edu.wpi.first.math.geometry.Pose2d;
+
+/** Mutable version of {@link Pose2d} */
+public class MutablePose2d {
+
+    private final MutableTranslation2d translation;
+    private final MutableRotation2d rotation;
+
+    public MutablePose2d() {
+        this(new MutableTranslation2d(), new MutableRotation2d());
+    }
+
+    public MutablePose2d(MutableTranslation2d translation, MutableRotation2d rotation) {
+        this.rotation = rotation;
+        this.translation = translation;
+    }
+
+    public MutablePose2d(Pose2d pose) {
+        this.rotation = new MutableRotation2d(pose.getRotation());
+        this.translation = new MutableTranslation2d(pose.getTranslation());
+    }
+
+    public MutableTranslation2d getTranslation() {
+        return translation;
+    }
+
+    public MutableRotation2d getRotation() {
+        return rotation;
+    }
+
+}

--- a/src/main/java/frc/lib/mut/MutableRotation2d.java
+++ b/src/main/java/frc/lib/mut/MutableRotation2d.java
@@ -1,0 +1,342 @@
+package frc.lib.mut;
+
+import static edu.wpi.first.units.Units.Radians;
+import java.util.Objects;
+import edu.wpi.first.math.MathSharedStore;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.units.measure.Angle;
+
+/**
+ * Mutable version of {@link Rotation2d}
+ *
+ * A rotation in a 2D coordinate frame represented by a point on the unit circle (cosine and sine).
+ *
+ * <p>
+ * The angle is continuous, that is if a Rotation2d is constructed with 361 degrees, it will return
+ * 361 degrees. This allows algorithms that wouldn't want to see a discontinuity in the rotations as
+ * it sweeps past from 360 to 0 on the second time around.
+ */
+public class MutableRotation2d {
+
+    private double value;
+    private double cos;
+    private double sin;
+
+    /** Constructs a Rotation2d with a default angle of 0 degrees. */
+    public MutableRotation2d() {
+        this.value = 0.0;
+        this.cos = 1.0;
+        this.sin = 0.0;
+    }
+
+    /** Construct from immutable */
+    public MutableRotation2d(Rotation2d imm) {
+        this.value = imm.getRadians();
+        this.cos = imm.getCos();
+        this.sin = imm.getSin();
+    }
+
+    /** Create immutable from this. */
+    public Rotation2d toImmutable() {
+        return new Rotation2d(value);
+    }
+
+    /**
+     * Constructs a Rotation2d with the given radian value.
+     *
+     * @param value The value of the angle in radians.
+     */
+    public void setRadians(double value) {
+        this.value = value;
+        this.cos = Math.cos(value);
+        this.sin = Math.sin(value);
+    }
+
+    /**
+     * Constructs a Rotation2d with the given x and y (cosine and sine) components.
+     *
+     * @param x The x component or cosine of the rotation.
+     * @param y The y component or sine of the rotation.
+     */
+    public void setXY(double x, double y) {
+        double magnitude = Math.hypot(x, y);
+        if (magnitude > 1e-6) {
+            this.cos = x / magnitude;
+            this.sin = y / magnitude;
+        } else {
+            this.cos = 1.0;
+            this.sin = 0.0;
+            MathSharedStore.reportError("x and y components of Rotation2d are zero\n",
+                Thread.currentThread().getStackTrace());
+        }
+        value = Math.atan2(this.sin, this.cos);
+    }
+
+    /**
+     * Constructs a Rotation2d with the given angle.
+     *
+     * @param angle The angle of the rotation.
+     */
+    public void setAngle(Angle angle) {
+        this.setRadians(angle.in(Radians));
+    }
+
+    /**
+     * Constructs and returns a Rotation2d with the given degree value.
+     *
+     * @param degrees The value of the angle in degrees.
+     */
+    public void setDegrees(double degrees) {
+        this.setRadians(Units.degreesToRadians(degrees));
+    }
+
+    /**
+     * Constructs and returns a Rotation2d with the given number of rotations.
+     *
+     * @param rotations The value of the angle in rotations.
+     * @see edu.wpi.first.math.MathUtil#angleModulus(double) to constrain the angle within (-π, π]
+     */
+    public void setRotations(double rotations) {
+        this.setRadians(Units.rotationsToRadians(rotations));
+    }
+
+    /**
+     * Adds two rotations together, with the result being bounded between -π and π.
+     *
+     * <p>
+     * For example, <code>Rotation2d.fromDegrees(30).plus(Rotation2d.fromDegrees(60))</code> equals
+     * <code>Rotation2d(Math.PI/2.0)</code>
+     *
+     * @param other The rotation to add.
+     * @param out out parameter
+     * @return The sum of the two rotations.
+     */
+    public MutableRotation2d plus(MutableRotation2d other, MutableRotation2d out) {
+        return rotateBy(other, out);
+    }
+
+    /**
+     * Adds two rotations together, with the result being bounded between -π and π.
+     *
+     * <p>
+     * For example, <code>Rotation2d.fromDegrees(30).plus(Rotation2d.fromDegrees(60))</code> equals
+     * <code>Rotation2d(Math.PI/2.0)</code>
+     *
+     * @param other The rotation to add.
+     * @param out out parameter
+     * @return The sum of the two rotations.
+     */
+    public MutableRotation2d plus(Rotation2d other, MutableRotation2d out) {
+        return rotateBy(other, out);
+    }
+
+    /**
+     * Adds two rotations together, with the result being bounded between -π and π.
+     *
+     * <p>
+     * For example, <code>Rotation2d.fromDegrees(30).plus(Rotation2d.fromDegrees(60))</code> equals
+     * <code>Rotation2d(Math.PI/2.0)</code>
+     *
+     * @param other The rotation to add.
+     * @return The sum of the two rotations.
+     */
+    public MutableRotation2d plus(MutableRotation2d other) {
+        return plus(other, new MutableRotation2d());
+    }
+
+    /**
+     * Adds two rotations together, with the result being bounded between -π and π.
+     *
+     * <p>
+     * For example, <code>Rotation2d.fromDegrees(30).plus(Rotation2d.fromDegrees(60))</code> equals
+     * <code>Rotation2d(Math.PI/2.0)</code>
+     *
+     * @param other The rotation to add.
+     * @return The sum of the two rotations.
+     */
+    public MutableRotation2d plus(Rotation2d other) {
+        return plus(other, new MutableRotation2d());
+    }
+
+    /**
+     * Subtracts the new rotation from the current rotation and returns the new rotation.
+     *
+     * <p>
+     * For example, <code>Rotation2d.fromDegrees(10).minus(Rotation2d.fromDegrees(100))</code>
+     * equals <code>Rotation2d(-Math.PI/2.0)</code>
+     *
+     * @param other The rotation to subtract.
+     * @param out out parameter
+     * @return The difference between the two rotations.
+     */
+    public MutableRotation2d minus(MutableRotation2d other, MutableRotation2d out) {
+        return rotateBy(-other.value, out);
+    }
+
+    /**
+     * Takes the inverse of the current rotation. This is simply the negative of the current angular
+     * value.
+     *
+     * @param out out parameter
+     * @return The inverse of the current rotation.
+     */
+    public MutableRotation2d unaryMinus(MutableRotation2d out) {
+        out.setRadians(-value);
+        return out;
+    }
+
+    /**
+     * Multiplies the current rotation by a scalar.
+     *
+     * @param scalar The scalar.
+     * @param out out parameter
+     * @return The new scaled Rotation2d.
+     */
+    public MutableRotation2d times(double scalar, MutableRotation2d out) {
+        out.setRadians(value * scalar);
+        return out;
+    }
+
+    /**
+     * Divides the current rotation by a scalar.
+     *
+     * @param scalar The scalar.
+     * @param out out parameter
+     * @return The new scaled Rotation2d.
+     */
+    public MutableRotation2d div(double scalar, MutableRotation2d out) {
+        return times(1.0 / scalar, out);
+    }
+
+    /**
+     * Adds the new rotation to the current rotation using a rotation matrix.
+     *
+     * <p>
+     * The matrix multiplication is as follows:
+     *
+     * <pre>
+     * [cos_new]   [other.cos, -other.sin][cos]
+     * [sin_new] = [other.sin,  other.cos][sin]
+     * value_new = atan2(sin_new, cos_new)
+     * </pre>
+     *
+     * @param other The rotation to rotate by.
+     * @param out out parameter
+     * @return The new rotated Rotation2d.
+     */
+    public MutableRotation2d rotateBy(MutableRotation2d other, MutableRotation2d out) {
+        out.setXY(cos * other.cos - sin * other.sin, cos * other.sin + sin * other.cos);
+        return out;
+    }
+
+    /**
+     * Adds the new rotation to the current rotation using a rotation matrix.
+     *
+     * <p>
+     * The matrix multiplication is as follows:
+     *
+     * <pre>
+     * [cos_new]   [other.cos, -other.sin][cos]
+     * [sin_new] = [other.sin,  other.cos][sin]
+     * value_new = atan2(sin_new, cos_new)
+     * </pre>
+     *
+     * @param other The rotation to rotate by.
+     * @param out out parameter
+     * @return The new rotated Rotation2d.
+     */
+    public MutableRotation2d rotateBy(Rotation2d other, MutableRotation2d out) {
+        out.setXY(cos * other.getCos() - sin * other.getSin(),
+            cos * other.getSin() + sin * other.getCos());
+        return out;
+    }
+
+    private MutableRotation2d rotateBy(double other, MutableRotation2d out) {
+        double other_cos = Math.cos(other);
+        double other_sin = Math.sin(other);
+        out.setXY(cos * other_cos - sin * other_sin, cos * other_sin + sin * other_cos);
+        return out;
+    }
+
+    /**
+     * Returns the radian value of the Rotation2d.
+     *
+     * @return The radian value of the Rotation2d.
+     */
+    public double getRadians() {
+        return value;
+    }
+
+    /**
+     * Returns the degree value of the Rotation2d.
+     *
+     * @return The degree value of the Rotation2d.
+     * @see edu.wpi.first.math.MathUtil#inputModulus(double, double, double) to constrain the angle
+     *      within (-180, 180]
+     */
+    public double getDegrees() {
+        return Math.toDegrees(value);
+    }
+
+    /**
+     * Returns the number of rotations of the Rotation2d.
+     *
+     * @return The number of rotations of the Rotation2d.
+     */
+    public double getRotations() {
+        return Units.radiansToRotations(value);
+    }
+
+    /**
+     * Returns the cosine of the Rotation2d.
+     *
+     * @return The cosine of the Rotation2d.
+     */
+    public double getCos() {
+        return cos;
+    }
+
+    /**
+     * Returns the sine of the Rotation2d.
+     *
+     * @return The sine of the Rotation2d.
+     */
+    public double getSin() {
+        return sin;
+    }
+
+    /**
+     * Returns the tangent of the Rotation2d.
+     *
+     * @return The tangent of the Rotation2d.
+     */
+    public double getTan() {
+        return sin / cos;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Rotation2d(Rads: %.2f, Deg: %.2f)", value, Math.toDegrees(value));
+    }
+
+    /**
+     * Checks equality between this Rotation2d and another object.
+     *
+     * @param obj The other object.
+     * @return Whether the two objects are equal or not.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return (obj instanceof Rotation2d other
+            && Math.hypot(cos - other.getCos(), sin - other.getSin()) < 1E-9)
+            || (obj instanceof MutableRotation2d other2
+                && Math.hypot(cos - other2.getCos(), sin - other2.getSin()) < 1E-9);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+}

--- a/src/main/java/frc/lib/mut/MutableSwerveModulePosition.java
+++ b/src/main/java/frc/lib/mut/MutableSwerveModulePosition.java
@@ -1,0 +1,27 @@
+package frc.lib.mut;
+
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+
+/** Mutable version of {@link SwerveModulePosition} */
+public class MutableSwerveModulePosition {
+
+    /** Distance measured by the wheel of the module. */
+    public double distanceMeters;
+
+    /** Angle of the module. */
+    public MutableRotation2d angle;
+
+    public MutableSwerveModulePosition(double distanceMeters, MutableRotation2d angle) {
+        this.distanceMeters = distanceMeters;
+        this.angle = angle;
+    }
+
+    public MutableSwerveModulePosition() {
+        this(0.0, new MutableRotation2d());
+    }
+
+    public SwerveModulePosition toImmutable() {
+        return new SwerveModulePosition(distanceMeters, angle.toImmutable());
+    }
+
+}

--- a/src/main/java/frc/lib/mut/MutableSwerveModuleState.java
+++ b/src/main/java/frc/lib/mut/MutableSwerveModuleState.java
@@ -1,0 +1,62 @@
+package frc.lib.mut;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+
+/** Mutable version of {@link SwerveModuleState} */
+public class MutableSwerveModuleState {
+
+    /** Speed of the wheel of the module. */
+    public double speedMetersPerSecond;
+
+    /** Angle of the module. */
+    public MutableRotation2d angle;
+
+    public MutableSwerveModuleState(double speedMetersPerSecond, MutableRotation2d angle) {
+        this.speedMetersPerSecond = speedMetersPerSecond;
+        this.angle = angle;
+    }
+
+    public MutableSwerveModuleState() {
+        this(0.0, new MutableRotation2d());
+    }
+
+    public SwerveModuleState toImmutable() {
+        return new SwerveModuleState(speedMetersPerSecond, angle.toImmutable());
+    }
+
+    public MutableSwerveModuleState fromImmutable(SwerveModuleState state) {
+        this.speedMetersPerSecond = state.speedMetersPerSecond;
+        this.angle.setRadians(state.angle.getRadians());
+        return this;
+    }
+
+    private final MutableRotation2d tempRotation = new MutableRotation2d();
+
+    /**
+     * Minimize the change in heading this swerve module state would require by potentially
+     * reversing the direction the wheel spins. If this is used with the PIDController class's
+     * continuous input functionality, the furthest a wheel will ever rotate is 90 degrees.
+     *
+     * @param currentAngle The current module angle.
+     */
+    public void optimize(MutableRotation2d currentAngle) {
+        var delta = angle.minus(currentAngle, tempRotation);
+        if (Math.abs(delta.getDegrees()) > 90.0) {
+            speedMetersPerSecond *= -1;
+            angle.rotateBy(Rotation2d.kPi, angle);
+        }
+    }
+
+    /**
+     * Scales speed by cosine of angle error. This scales down movement perpendicular to the desired
+     * direction of travel that can occur when modules change directions. This results in smoother
+     * driving.
+     *
+     * @param currentAngle The current module angle.
+     */
+    public void cosineScale(MutableRotation2d currentAngle) {
+        speedMetersPerSecond *= angle.minus(currentAngle, tempRotation).getCos();
+    }
+
+}

--- a/src/main/java/frc/lib/mut/MutableTranslation2d.java
+++ b/src/main/java/frc/lib/mut/MutableTranslation2d.java
@@ -1,0 +1,104 @@
+package frc.lib.mut;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+
+/** Mutable version of {@link Translation2d} */
+public class MutableTranslation2d {
+
+    private double x;
+    private double y;
+
+    public MutableTranslation2d() {
+        this(0.0, 0.0);
+    }
+
+    public MutableTranslation2d(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public MutableTranslation2d(Translation2d other) {
+        this.x = other.getX();
+        this.y = other.getY();
+    }
+
+    public Translation2d toImmutable() {
+        return new Translation2d(x, y);
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public MutableTranslation2d setXY(double x, double y) {
+        this.x = x;
+        this.y = y;
+        return this;
+    }
+
+    public MutableTranslation2d rotateBy(MutableRotation2d rotation, MutableTranslation2d out) {
+        double x = this.x * rotation.getCos() - this.y * rotation.getSin();
+        double y = this.x * rotation.getSin() + this.y * rotation.getCos();
+        return out.setXY(x, y);
+    }
+
+    public MutableTranslation2d setDistanceAngle(double distance, MutableRotation2d angle) {
+        return this.setXY(distance * angle.getCos(), distance * angle.getSin());
+    }
+
+    public MutableTranslation2d setDistanceAngle(double distance, Rotation2d angle) {
+        return this.setXY(distance * angle.getCos(), distance * angle.getSin());
+    }
+
+    public MutableTranslation2d setDistanceAngle(double distance, double radians) {
+        return this.setXY(distance * Math.cos(radians), distance * Math.sin(radians));
+    }
+
+    public double getNorm() {
+        return Math.hypot(x, y);
+    }
+
+    public MutableRotation2d getAngle(MutableRotation2d out) {
+        // TODO
+        return out;
+    }
+
+    public MutableTranslation2d plus(MutableTranslation2d other, MutableTranslation2d out) {
+        // TODO
+        return out;
+    }
+
+    public MutableTranslation2d minus(MutableTranslation2d other, MutableTranslation2d out) {
+        // TODO
+        return out;
+    }
+
+    public MutableTranslation2d unaryMinus(MutableTranslation2d out) {
+        // TODO
+        return out;
+    }
+
+    public MutableTranslation2d times(double scalar, MutableTranslation2d out) {
+        // TODO
+        return out;
+    }
+
+    public MutableTranslation2d div(double scalar, MutableTranslation2d out) {
+        // TODO
+        return out;
+    }
+
+}

--- a/src/main/java/frc/lib/util/SmallVec.java
+++ b/src/main/java/frc/lib/util/SmallVec.java
@@ -1,0 +1,86 @@
+package frc.lib.util;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.function.IntFunction;
+
+/** An array-backed list with fixed capacity. */
+public final class SmallVec<T> {
+
+    private final Object[] backing;
+    private int size = 0;
+
+    /** Create a new SmallVec with given capacity */
+    public SmallVec(int capacity) {
+        backing = new Object[capacity];
+    }
+
+    /**
+     * Appends {@code value} to the end of this list.
+     */
+    public void add(final T value) {
+        backing[size++] = value;
+    }
+
+    /**
+     * Get long element at index {@code index}.
+     */
+    @SuppressWarnings("unchecked")
+    public T get(int index) {
+        Objects.checkIndex(index, size);
+        return (T) backing[index];
+    }
+
+    /**
+     * Checks if the list has no elements.
+     */
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    /**
+     * Returns the number of elements in this list.
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * Removes the element at the specified position in this list.
+     */
+    @SuppressWarnings("unchecked")
+    public T remove(final int index) {
+        Objects.checkIndex(index, size);
+        final Object[] a = this.backing;
+        final Object old = a[index];
+        size--;
+        if (index != size) {
+            System.arraycopy(a, index + 1, a, index, size);
+        }
+        assert size <= a.length;
+        return (T) old;
+    }
+
+    /** Remove all values. */
+    public void clear() {
+        this.size = 0;
+    }
+
+    /**
+     * Convert to an array. This performs a copy, since the backing array may be larger than the
+     * array needed to be returned.
+     */
+    public T[] toArray(IntFunction<T[]> newFunc) {
+        T[] result = newFunc.apply(size);
+        System.arraycopy(backing, 0, result, 0, size);
+        return result;
+    }
+
+    /** Sort the list */
+    @SuppressWarnings("unchecked")
+    public void sort(Comparator<? super T> c) {
+        Arrays.sort((T[]) backing, 0, size, c);
+    }
+
+}

--- a/src/main/java/frc/lib/util/swerve/SwerveModuleIO.java
+++ b/src/main/java/frc/lib/util/swerve/SwerveModuleIO.java
@@ -1,5 +1,7 @@
 package frc.lib.util.swerve;
 
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
 import org.littletonrobotics.junction.AutoLog;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
@@ -9,10 +11,10 @@ public interface SwerveModuleIO {
     /** Inputs Class for SwerveModule */
     @AutoLog
     public static class SwerveModuleInputs {
-        public Angle driveMotorSelectedPosition;
-        public AngularVelocity driveMotorSelectedSensorVelocity;
-        public Angle angleMotorSelectedPosition;
-        public Angle absolutePositionAngleEncoder;
+        public Angle driveMotorSelectedPosition = Rotations.of(0.0);
+        public AngularVelocity driveMotorSelectedSensorVelocity = RotationsPerSecond.of(0.0);
+        public Angle angleMotorSelectedPosition = Rotations.of(0.0);
+        public Angle absolutePositionAngleEncoder = Rotations.of(0.0);
         // public double driveMotorTemp;
         // public double angleMotorTemp;
     }

--- a/src/main/java/frc/lib/util/viz/Viz2025.java
+++ b/src/main/java/frc/lib/util/viz/Viz2025.java
@@ -97,6 +97,9 @@ public class Viz2025 implements Drawable {
         mechanisms[CLIMBER_ID] = new Pose3d(Translation3d.kZero, Rotation3d.kZero);
     }
 
+    private Rotation3d prevRotation = new Rotation3d();
+    private double prevAlgaeAngle = 0.0;
+
     /** Publish all values to Logger */
     @Override
     public void drawImpl() {
@@ -120,7 +123,15 @@ public class Viz2025 implements Drawable {
         mechanisms[STAGE4_ID] =
             new Pose3d(new Translation3d(0, 0, Math.min(elevatorHeight, 1.96337 - 0.226559)),
                 Rotation3d.kZero);
-        Rotation3d algaeRotation3d = new Rotation3d(0.0, Units.degreesToRadians(algaeAngle), 0.0);
+
+        Rotation3d algaeRotation3d;
+        if (Math.abs(algaeAngle - prevAlgaeAngle) < 0.1) {
+            algaeRotation3d = prevRotation;
+        } else {
+            algaeRotation3d = new Rotation3d(0.0, Units.degreesToRadians(algaeAngle), 0.0);
+        }
+        prevRotation = algaeRotation3d;
+        prevAlgaeAngle = algaeAngle;
         Translation3d algaeTranslation3d = new Translation3d(0.13335, 0.006358,
             0.615387 + Math.min(elevatorHeight, 1.96337 - 0.226559));
         mechanisms[ALGAE_ID] = new Pose3d(algaeTranslation3d, algaeRotation3d);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -19,6 +19,7 @@ import frc.lib.util.viz.Viz2025;
 import frc.robot.Robot.RobotRunType;
 import frc.robot.subsystems.LEDs;
 import frc.robot.subsystems.climber.Climber;
+import frc.robot.subsystems.climber.ClimberIO;
 import frc.robot.subsystems.climber.ClimberReal;
 import frc.robot.subsystems.coral.CoralScoring;
 import frc.robot.subsystems.coral.CoralScoringIO;
@@ -26,11 +27,9 @@ import frc.robot.subsystems.coral.CoralScoringReal;
 import frc.robot.subsystems.swerve.Swerve;
 import frc.robot.subsystems.swerve.SwerveIO;
 import frc.robot.subsystems.swerve.SwerveReal;
-import frc.robot.subsystems.swerve.SwerveSim;
 import frc.robot.subsystems.vision.Vision;
 import frc.robot.subsystems.vision.VisionIO;
 import frc.robot.subsystems.vision.VisionReal;
-import frc.robot.subsystems.vision.VisionSimPhoton;
 
 
 
@@ -80,17 +79,20 @@ public class RobotContainer {
                 coralScoring = new CoralScoring(new CoralScoringReal());
                 climb = new Climber(new ClimberReal());
                 break;
-            case kSimulation:
-                driveSimulation = new SwerveDriveSimulation(Constants.Swerve.getMapleConfig(),
-                    new Pose2d(3, 3, Rotation2d.kZero));
-                SimulatedArena.getInstance().addDriveTrainSimulation(driveSimulation);
-                s_Swerve = new Swerve(state, new SwerveSim(driveSimulation));
-                s_Vision = new Vision(state, VisionSimPhoton.partial(driveSimulation));
-                coralScoring = new CoralScoring(new CoralScoringIO() {});
-                break;
+            // case kSimulation:
+            // driveSimulation = new SwerveDriveSimulation(Constants.Swerve.getMapleConfig(),
+            // new Pose2d(3, 3, Rotation2d.kZero));
+            // SimulatedArena.getInstance().addDriveTrainSimulation(driveSimulation);
+            // s_Swerve = new Swerve(state, new SwerveSim(driveSimulation));
+            // s_Vision = new Vision(state, VisionSimPhoton.partial(driveSimulation));
+            // coralScoring = new CoralScoring(new CoralScoringIO() {});
+            // climb = new Climber(new ClimberIO.Empty());
+            // break;
             default:
                 s_Swerve = new Swerve(state, new SwerveIO.Empty() {});
                 s_Vision = new Vision(state, VisionIO::empty);
+                coralScoring = new CoralScoring(new CoralScoringIO() {});
+                climb = new Climber(new ClimberIO.Empty());
         }
         /* Default Commands */
         s_Swerve.setDefaultCommand(s_Swerve.teleOpDrive(driver, Constants.Swerve.isFieldRelative,

--- a/src/main/java/frc/robot/RobotState.java
+++ b/src/main/java/frc/robot/RobotState.java
@@ -16,6 +16,7 @@ import frc.lib.math.Hexagon;
 import frc.lib.math.Penetration;
 import frc.lib.math.Rectangle;
 import frc.lib.math.SeparatingAxis;
+import frc.lib.mut.MutableTranslation2d;
 import frc.lib.util.viz.Viz2025;
 import frc.robot.subsystems.swerve.Swerve;
 
@@ -99,18 +100,15 @@ public class RobotState {
         double y = original.getY();
         double t = -original.getRotation().getRadians();
 
-        Translation2d[] bumpers = new Translation2d[5];
-        Translation2d[] tr = new Translation2d[4];
+
         for (int i = 0; i < 4; i++) {
             double theta = t + i * Math.PI / 2;
-            tr[i] = new Translation2d(
+            tr[i].setXY(
                 x + Math.cos(theta) * Constants.Swerve.bumperFront.in(Meters)
                     + Math.sin(theta) * Constants.Swerve.bumperRight.in(Meters),
                 y - Math.sin(theta) * Constants.Swerve.bumperFront.in(Meters)
                     + Math.cos(theta) * Constants.Swerve.bumperRight.in(Meters));
-            bumpers[i] = tr[i];
         }
-        bumpers[4] = bumpers[0];
 
         double dx = 0.0;
         double dy = 0.0;
@@ -222,15 +220,12 @@ public class RobotState {
         robot.draw();
 
         if (Constants.StateEstimator.keepOutOfReefs) {
-            Penetration penetration = new Penetration("ReefPen");
-            Translation2d[] sepResult =
-                new Translation2d[] {Translation2d.kZero, Translation2d.kZero};
             if (SeparatingAxis.solve(robot, reef1, penetration)) {
                 sepResult[0] = robot.getCenter();
-                Translation2d offs = new Translation2d(penetration.getDepth(),
-                    new Rotation2d(penetration.getXDir(), penetration.getYDir()));
-                Translation2d resPos = robot.getCenter().plus(offs);
-                robotTest.setPose(new Pose2d(resPos, original.getRotation()));
+                penetration.update(offs);
+                robot.getCenter().plus(offs, resPos);
+                robotTest.setPose(resPos.getX(), resPos.getY(),
+                    original.getRotation().getRadians());
                 sepResult[1] = robotTest.getCenter();
                 penetration.draw();
 
@@ -238,10 +233,10 @@ public class RobotState {
                 dy = offs.getY();
             } else if (SeparatingAxis.solve(robot, reef2, penetration)) {
                 sepResult[0] = robot.getCenter();
-                Translation2d offs = new Translation2d(penetration.getDepth(),
-                    new Rotation2d(penetration.getXDir(), penetration.getYDir()));
-                Translation2d resPos = robot.getCenter().plus(offs);
-                robotTest.setPose(new Pose2d(resPos, original.getRotation()));
+                penetration.update(offs);
+                robot.getCenter().plus(offs, resPos);
+                robotTest.setPose(resPos.getX(), resPos.getY(),
+                    original.getRotation().getRadians());
                 sepResult[1] = robotTest.getCenter();
                 penetration.draw();
 
@@ -249,10 +244,10 @@ public class RobotState {
                 dy = offs.getY();
             } else if (SeparatingAxis.solve(robot, centerPost, penetration)) {
                 sepResult[0] = robot.getCenter();
-                Translation2d offs = new Translation2d(penetration.getDepth(),
-                    new Rotation2d(penetration.getXDir(), penetration.getYDir()));
-                Translation2d resPos = robot.getCenter().plus(offs);
-                robotTest.setPose(new Pose2d(resPos, original.getRotation()));
+                penetration.update(offs);
+                robot.getCenter().plus(offs, resPos);
+                robotTest.setPose(resPos.getX(), resPos.getY(),
+                    original.getRotation().getRadians());
                 sepResult[1] = robotTest.getCenter();
                 penetration.draw();
 
@@ -262,17 +257,23 @@ public class RobotState {
                 robotTest.setPose(new Pose2d(-100, -100, Rotation2d.kZero));
             }
             robotTest.draw();
-
-            Logger.recordOutput("sepResult", sepResult);
         }
-
-        // TODO
 
         if (Math.abs(dx) > 0.01 || Math.abs(dy) > 0.01) {
             resetPose(new Pose2d(x + dx, y + dy, original.getRotation()), positions, gyroYaw);
             return;
         }
     }
+
+    private final MutableTranslation2d[] tr =
+        new MutableTranslation2d[] {new MutableTranslation2d(), new MutableTranslation2d(),
+            new MutableTranslation2d(), new MutableTranslation2d(),};
+
+    private final Penetration penetration = new Penetration("ReefPen");
+    private final MutableTranslation2d[] sepResult =
+        new MutableTranslation2d[] {new MutableTranslation2d(), new MutableTranslation2d()};
+    private final MutableTranslation2d resPos = new MutableTranslation2d();
+    private final MutableTranslation2d offs = new MutableTranslation2d();
 
     private final Hexagon reef1 = new Hexagon("BlueReef", FieldConstants.Reef.center,
         FieldConstants.Reef.circumscribedRadius.in(Meters), Rotation2d.fromDegrees(30));

--- a/src/main/java/frc/robot/subsystems/climber/ClimberIO.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberIO.java
@@ -25,5 +25,23 @@ public interface ClimberIO {
 
     public void setEncoderPoisiton(double position);
 
+    public static class Empty implements ClimberIO {
+
+        @Override
+        public void updateInputs(ClimberInputs inputs) {
+
+        }
+
+        @Override
+        public void setClimbMotorVoltage(double voltage) {
+
+        }
+
+        @Override
+        public void setEncoderPoisiton(double position) {
+
+        }
+
+    }
 
 }

--- a/src/main/java/frc/robot/subsystems/swerve/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/swerve/Swerve.java
@@ -17,6 +17,7 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import frc.lib.mut.MutableSwerveModuleState;
 import frc.lib.util.swerve.SwerveModule;
 import frc.robot.Constants;
 import frc.robot.RobotState;
@@ -65,6 +66,10 @@ public class Swerve extends SubsystemBase {
         setModuleStates(chassisSpeeds);
     }
 
+    private final MutableSwerveModuleState[] desiredStates = new MutableSwerveModuleState[] {
+        new MutableSwerveModuleState(), new MutableSwerveModuleState(),
+        new MutableSwerveModuleState(), new MutableSwerveModuleState(),};
+
     /**
      * Set Swerve Module States
      *
@@ -74,7 +79,9 @@ public class Swerve extends SubsystemBase {
         SwerveDriveKinematics.desaturateWheelSpeeds(desiredStates, Constants.Swerve.maxSpeed);
         Logger.recordOutput("/Swerve/DesiredStates", desiredStates);
         for (SwerveModule mod : swerveMods) {
-            mod.setDesiredState(desiredStates[mod.moduleNumber], false);
+            mod.setDesiredState(
+                this.desiredStates[mod.moduleNumber].fromImmutable(desiredStates[mod.moduleNumber]),
+                false);
         }
     }
 
@@ -108,7 +115,7 @@ public class Swerve extends SubsystemBase {
     public SwerveModuleState[] getModuleStates() {
         SwerveModuleState[] states = new SwerveModuleState[4];
         for (SwerveModule mod : swerveMods) {
-            states[mod.moduleNumber] = mod.getState();
+            states[mod.moduleNumber] = mod.getState().toImmutable();
         }
         return states;
     }
@@ -121,7 +128,7 @@ public class Swerve extends SubsystemBase {
     public SwerveModulePosition[] getModulePositions() {
         SwerveModulePosition[] positions = new SwerveModulePosition[4];
         for (SwerveModule mod : swerveMods) {
-            positions[mod.moduleNumber] = mod.getPosition();
+            positions[mod.moduleNumber] = mod.getPosition().toImmutable();
         }
         return positions;
     }
@@ -205,11 +212,14 @@ public class Swerve extends SubsystemBase {
      * Make an X pattern with the wheels
      */
     public void wheelsIn() {
-        swerveMods[0].setDesiredState(new SwerveModuleState(2, Rotation2d.fromDegrees(45)), false);
-        swerveMods[1].setDesiredState(new SwerveModuleState(2, Rotation2d.fromDegrees(135)), false);
-        swerveMods[2].setDesiredState(new SwerveModuleState(2, Rotation2d.fromDegrees(-45)), false);
-        swerveMods[3].setDesiredState(new SwerveModuleState(2, Rotation2d.fromDegrees(-135)),
-            false);
+        swerveMods[0].setDesiredState(this.desiredStates[0]
+            .fromImmutable(new SwerveModuleState(2, Rotation2d.fromDegrees(45))), false);
+        swerveMods[1].setDesiredState(this.desiredStates[0]
+            .fromImmutable(new SwerveModuleState(2, Rotation2d.fromDegrees(135))), false);
+        swerveMods[2].setDesiredState(this.desiredStates[0]
+            .fromImmutable(new SwerveModuleState(2, Rotation2d.fromDegrees(-45))), false);
+        swerveMods[3].setDesiredState(this.desiredStates[0]
+            .fromImmutable(new SwerveModuleState(2, Rotation2d.fromDegrees(-135))), false);
         this.setMotorsZero();
     }
 
@@ -219,7 +229,7 @@ public class Swerve extends SubsystemBase {
     public SwerveModulePosition[] getSwerveModulePositions() {
         SwerveModulePosition[] positions = new SwerveModulePosition[4];
         for (SwerveModule mod : swerveMods) {
-            positions[mod.moduleNumber] = mod.getPosition();
+            positions[mod.moduleNumber] = mod.getPosition().toImmutable();
         }
         return positions;
     }


### PR DESCRIPTION
![Profiling](https://github.com/user-attachments/assets/bf444a11-6526-4436-be4b-d34cd392ddda)

Reduces GC pressure by reusing objects that have a lifetime smaller-than-or-equal-to the loop lifetime. This is done by using mutable versions of `Translation2d`, `Rotation2d` and `Pose2d`, which collision response made heavy use of. Over a minute test, these changes reduced the number of allocated bytes by ~78%.